### PR TITLE
Deployment strategy implementation

### DIFF
--- a/src/Accompli.php
+++ b/src/Accompli.php
@@ -4,6 +4,7 @@ namespace Accompli;
 
 use Accompli\Configuration\ConfigurationInterface;
 use Accompli\DependencyInjection\AwarenessCompilerPass;
+use Accompli\DependencyInjection\ConfigurationServiceRegistrationCompilerPass;
 use Nijens\Utilities\ObjectFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -155,6 +156,7 @@ class Accompli
     protected function buildContainer()
     {
         $container = new ContainerBuilder($this->parameters);
+        $container->addCompilerPass(new ConfigurationServiceRegistrationCompilerPass());
         $container->addCompilerPass(new AwarenessCompilerPass());
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Resources'));

--- a/src/Accompli.php
+++ b/src/Accompli.php
@@ -144,7 +144,7 @@ class Accompli
      */
     public function install($version, $stage = null)
     {
-        $deploymentStrategy = $this->container->get('deployment_strategy');
+        $deploymentStrategy = $this->getContainer()->get('deployment_strategy');
         $deploymentStrategy->install($version, $stage);
     }
 
@@ -156,7 +156,7 @@ class Accompli
      */
     public function deploy($version, $stage)
     {
-        $deploymentStrategy = $this->container->get('deployment_strategy');
+        $deploymentStrategy = $this->getContainer()->get('deployment_strategy');
         $deploymentStrategy->deploy($version, $stage);
     }
 

--- a/src/Accompli.php
+++ b/src/Accompli.php
@@ -149,6 +149,18 @@ class Accompli
     }
 
     /**
+     * Triggers the deployment on the configured deployment strategy.
+     *
+     * @param string $version
+     * @param string $stage
+     */
+    public function deploy($version, $stage)
+    {
+        $deploymentStrategy = $this->container->get('deployment_strategy');
+        $deploymentStrategy->deploy($version, $stage);
+    }
+
+    /**
      * Builds the service container.
      *
      * @return ContainerBuilder

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -256,6 +256,28 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getDeploymentStrategyClass()
+    {
+        if (isset($this->configuration['deployment']['strategy'])) {
+            return $this->configuration['deployment']['strategy'];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeploymentConnectionClasses()
+    {
+        if (isset($this->configuration['deployment']['connection'])) {
+            return $this->configuration['deployment']['connection'];
+        }
+
+        return array();
+    }
+
+    /**
      * Returns the entire configuration as array.
      *
      * @return array

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -49,4 +49,18 @@ interface ConfigurationInterface
      * @return array
      */
     public function getEventListeners();
+
+    /**
+     * Returns the classname of the configured deployment strategy.
+     *
+     * @return string
+     */
+    public function getDeploymentStrategyClass();
+
+    /**
+     * Returns the classnames of the configured deployment connections.
+     *
+     * return array
+     */
+    public function getDeploymentConnectionClasses();
 }

--- a/src/Console/Command/DeployReleaseCommand.php
+++ b/src/Console/Command/DeployReleaseCommand.php
@@ -23,7 +23,8 @@ class DeployReleaseCommand extends Command
             ->setName('deploy-release')
             ->setDescription('Deploys a release to all configured hosts of a stage.')
             ->addArgument('version', InputArgument::REQUIRED, 'The version to deploy.')
-            ->addArgument('stage', InputArgument::REQUIRED, 'The stage to select hosts for.');
+            ->addArgument('stage', InputArgument::REQUIRED, 'The stage to select hosts for.')
+            ->addOption('project-dir', null, InputOption::VALUE_OPTIONAL, 'The location of the project directory.', getcwd());
     }
 
     /**
@@ -34,6 +35,12 @@ class DeployReleaseCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
+        $parameters = new ParameterBag();
+        $parameters->set('configuration.file', $input->getOption('project-dir').DIRECTORY_SEPARATOR.'accompli.json');
+        $parameters->set('console.output_interface', $output);
+
+        $accompli = new Accompli($parameters);
+        $accompli->initialize();
+        $accompli->deploy($input->getArgument('version'), $input->getArgument('stage'));
     }
 }

--- a/src/Console/Command/InstallReleaseCommand.php
+++ b/src/Console/Command/InstallReleaseCommand.php
@@ -40,18 +40,10 @@ class InstallReleaseCommand extends Command
     {
         $parameters = new ParameterBag();
         $parameters->set('configuration.file', $input->getOption('project-dir').DIRECTORY_SEPARATOR.'accompli.json');
+        $parameters->set('console.output_interface', $output);
 
         $accompli = new Accompli($parameters);
         $accompli->initialize();
-
-        $configuration = $accompli->getConfiguration();
-        $hosts = $configuration->getHosts();
-        if ($input->getArgument('stage') !== null) {
-            $hosts = $configuration->getHostsByStage($input->getArgument('stage'));
-        }
-
-        foreach ($hosts as $host) {
-            $accompli->installRelease($host);
-        }
+        $accompli->install($input->getArgument('version'), $input->getArgument('stage'));
     }
 }

--- a/src/DependencyInjection/ConfigurationServiceRegistrationCompilerPass.php
+++ b/src/DependencyInjection/ConfigurationServiceRegistrationCompilerPass.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Accompli\DependencyInjection;
+
+use Accompli\Configuration\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ConfigurationServiceRegistrationCompilerPass.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ConfigurationServiceRegistrationCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Adds deployment classes, defined in the configuration service, as services.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $configuration = $container->get('configuration', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+        if ($configuration instanceof ConfigurationInterface) {
+            $this->registerService($container, 'deployment_strategy', $configuration->getDeploymentStrategyClass());
+
+            foreach ($configuration->getDeploymentConnectionClasses() as $connectionId => $connectionClass) {
+                $this->registerService($container, $connectionId.'_connection', $connectionClass);
+            }
+        }
+    }
+
+    /**
+     * Registers a service with the service container when the class exists.
+     *
+     * @param ContainerBuilder $container
+     * @param string           $serviceId
+     * @param string           $serviceClass
+     */
+    private function registerService(ContainerBuilder $container, $serviceId, $serviceClass)
+    {
+        if (class_exists($serviceClass)) {
+            $container->register($serviceId, $serviceClass);
+        }
+    }
+}

--- a/src/Deployment/Strategy/AbstractDeploymentStrategy.php
+++ b/src/Deployment/Strategy/AbstractDeploymentStrategy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Accompli\Deployment\Strategy;
+
+use Accompli\Configuration\ConfigurationInterface;
+use Accompli\DependencyInjection\ConfigurationAwareInterface;
+use Accompli\DependencyInjection\EventDispatcherAwareInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * AbstractDeploymentStrategy.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface, ConfigurationAwareInterface, EventDispatcherAwareInterface
+{
+    /**
+     * The configuration instance.
+     *
+     * @var ConfigurationInterface
+     */
+    protected $configuration;
+
+    /**
+     * The event dispatcher instance.
+     *
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deploy($version, $stage = null)
+    {
+    }
+}

--- a/src/Deployment/Strategy/DeploymentStrategyInterface.php
+++ b/src/Deployment/Strategy/DeploymentStrategyInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Accompli\Deployment\Strategy;
+
+/**
+ * DeploymentStrategyInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface DeploymentStrategyInterface
+{
+    /**
+     * Installs a release according to the deployment strategy.
+     *
+     * @param string      $version
+     * @param string|null $stage
+     */
+    public function install($version, $stage = null);
+
+    /**
+     * Deploys a release according to the deployment strategy.
+     *
+     * @param string      $version
+     * @param string|null $stage
+     */
+    public function deploy($version, $stage = null);
+}

--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Accompli\Deployment\Strategy;
+
+use Accompli\AccompliEvents;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
+use Accompli\Event\FailedEvent;
+use Accompli\Event\InstallReleaseEvent;
+use Accompli\Event\PrepareReleaseEvent;
+use Accompli\Event\PrepareWorkspaceEvent;
+
+/**
+ * RemoteInstallStrategy.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class RemoteInstallStrategy extends AbstractDeploymentStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function install($version, $stage = null)
+    {
+        $hosts = $this->configuration->getHosts();
+        if ($stage !== null) {
+            $hosts = $this->configuration->getHostsByStage($stage);
+        }
+
+        foreach ($hosts as $host) {
+            $prepareWorkspaceEvent = new PrepareWorkspaceEvent($host);
+            $this->eventDispatcher->dispatch(AccompliEvents::PREPARE_WORKSPACE, $prepareWorkspaceEvent);
+
+            $workspace = $prepareWorkspaceEvent->getWorkspace();
+            if ($workspace instanceof Workspace) {
+                $prepareReleaseEvent = new PrepareReleaseEvent($workspace, $version);
+                $this->eventDispatcher->dispatch(AccompliEvents::PREPARE_RELEASE, $prepareReleaseEvent);
+
+                $release = $prepareReleaseEvent->getRelease();
+                if ($release instanceof Release) {
+                    $installReleaseEvent = new InstallReleaseEvent($release);
+                    $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE, $installReleaseEvent);
+
+                    return;
+                }
+            }
+
+            $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE_FAILED, new FailedEvent());
+        }
+    }
+}

--- a/src/Event/PrepareReleaseEvent.php
+++ b/src/Event/PrepareReleaseEvent.php
@@ -21,6 +21,13 @@ class PrepareReleaseEvent extends Event
     private $workspace;
 
     /**
+     * The version string.
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
      * The Release instance.
      *
      * @var Release
@@ -31,10 +38,12 @@ class PrepareReleaseEvent extends Event
      * Constructs a new PrepareReleaseEvent.
      *
      * @param Workspace $workspace
+     * @param string    $version
      */
-    public function __construct(Workspace $workspace)
+    public function __construct(Workspace $workspace, $version)
     {
         $this->workspace = $workspace;
+        $this->version = $version;
     }
 
     /**

--- a/src/Event/PrepareReleaseEvent.php
+++ b/src/Event/PrepareReleaseEvent.php
@@ -2,8 +2,8 @@
 
 namespace Accompli\Event;
 
+use Accompli\Deployment\Release;
 use Accompli\Deployment\Workspace;
-use Accompli\Release;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -54,6 +54,16 @@ class PrepareReleaseEvent extends Event
     public function setRelease(Release $release)
     {
         $this->release = $release;
+    }
+
+    /**
+     * Returns the version.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
     }
 
     /**

--- a/src/Event/PrepareWorkspaceEvent.php
+++ b/src/Event/PrepareWorkspaceEvent.php
@@ -48,6 +48,16 @@ class PrepareWorkspaceEvent extends Event
     }
 
     /**
+     * Returns the Host instance.
+     *
+     * @return Host
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
      * Returns the Workspace instance.
      *
      * @return Workspace|null

--- a/src/Resources/accompli-defaults.json
+++ b/src/Resources/accompli-defaults.json
@@ -6,6 +6,7 @@
         ]
     },
     "deployment": {
+        "strategy": "Accompli\\Deployment\\Strategy\\RemoteInstallStrategy",
         "connection": {
             "local": "Accompli\\Deployment\\Connection\\LocalConnectionAdapter",
             "ssh": "Accompli\\Deployment\\Connection\\SSHConnectionAdapter"

--- a/src/Resources/accompli-schema.json
+++ b/src/Resources/accompli-schema.json
@@ -7,9 +7,6 @@
         "$extend": {
             "type": "string"
         },
-        "strategy": {
-            "type": "string"
-        },
         "hosts": {
             "type": "array",
             "items": {
@@ -66,11 +63,15 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "strategy": {
+                    "type": "string"
+                },
                 "connection": {
                     "type": "object",
                     "additionalProperties": true
                 }
-            }
+            },
+            "required": ["strategy"]
         }
     },
     "required": ["hosts", "events"]

--- a/src/Resources/accompli-schema.json
+++ b/src/Resources/accompli-schema.json
@@ -74,5 +74,5 @@
             "required": ["strategy"]
         }
     },
-    "required": ["hosts", "events"]
+    "required": ["hosts", "events", "deployment"]
 }

--- a/tests/AccompliTest.php
+++ b/tests/AccompliTest.php
@@ -3,6 +3,7 @@
 namespace Accompli\Test;
 
 use Accompli\Accompli;
+use Accompli\Deployment\Host;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -99,6 +100,66 @@ class AccompliTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $eventDispatcher->getListeners('listener_event'));
         $this->assertInternalType('array', $eventDispatcher->getListeners('subscribed_event'));
         $this->assertCount(1, $eventDispatcher->getListeners('subscribed_event'));
+    }
+
+    /**
+     * Tests if Accompli::install calls the install method on the deployment strategy registered in the service container.
+     */
+    public function testInstall()
+    {
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $deploymentStrategyMock->expects($this->once())
+                ->method('install')
+                ->with(
+                    $this->equalTo('0.1.0'),
+                    $this->equalTo(null)
+                );
+
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $containerMock->expects($this->once())
+                ->method('get')
+                ->with($this->equalTo('deployment_strategy'))
+                ->willReturn($deploymentStrategyMock);
+
+        $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
+
+        $accompli = $this->getMockBuilder('Accompli\Accompli')
+                ->setConstructorArgs(array($parameterBagMock))
+                ->setMethods(array('getContainer'))
+                ->getMock();
+        $accompli->expects($this->once())->method('getContainer')->willReturn($containerMock);
+
+        $accompli->install('0.1.0');
+    }
+
+    /**
+     * Tests if Accompli::deploy calls the deploy method on the deployment strategy registered in the service container.
+     */
+    public function testDeploy()
+    {
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $deploymentStrategyMock->expects($this->once())
+                ->method('deploy')
+                ->with(
+                    $this->equalTo('0.1.0'),
+                    $this->equalTo(Host::STAGE_TEST)
+                );
+
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $containerMock->expects($this->once())
+                ->method('get')
+                ->with($this->equalTo('deployment_strategy'))
+                ->willReturn($deploymentStrategyMock);
+
+        $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
+
+        $accompli = $this->getMockBuilder('Accompli\Accompli')
+                ->setConstructorArgs(array($parameterBagMock))
+                ->setMethods(array('getContainer'))
+                ->getMock();
+        $accompli->expects($this->once())->method('getContainer')->willReturn($containerMock);
+
+        $accompli->deploy('0.1.0', Host::STAGE_TEST);
     }
 
     /**

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -214,4 +214,49 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
     }
+
+    /**
+     * Tests if Configuration::getDeploymentStrategyClass returns null when the configuration is not loaded.
+     */
+    public function testGetDeploymentStrategyClassReturnsNullWhenConfigurationNotLoaded()
+    {
+        $configuration = new Configuration();
+
+        $this->assertNull($configuration->getDeploymentStrategyClass());
+    }
+
+    /**
+     * Tests if Configuration::getDeploymentStrategyClass returns a valid classname when the configuration is loaded.
+     */
+    public function testGetDeploymentStrategyClassReturnsValidClassName()
+    {
+        $configuration = new Configuration();
+        $configuration->load(__DIR__.'/../Resources/accompli-extended.json');
+
+        $this->assertInternalType('string', $configuration->getDeploymentStrategyClass());
+        $this->assertTrue(class_exists($configuration->getDeploymentStrategyClass()));
+    }
+
+    /**
+     * Tests if Configuration::getDeploymentConnectionClasses returns an empty array when the configuration is not loaded.
+     */
+    public function testGetDeploymentDeploymentConnectionClassesReturnsEmptyArrayWhenConfigurationNotLoaded()
+    {
+        $configuration = new Configuration();
+
+        $this->assertInternalType('array', $configuration->getDeploymentConnectionClasses());
+        $this->assertEmpty($configuration->getDeploymentConnectionClasses());
+    }
+
+    /**
+     * Tests if Configuration::getDeploymentConnectionClasses returns a filled array with at least the 'local' key.
+     */
+    public function testGetDeploymentDeploymentConnectionClassesReturnsArray()
+    {
+        $configuration = new Configuration();
+        $configuration->load(__DIR__.'/../Resources/accompli-extended.json');
+
+        $this->assertInternalType('array', $configuration->getDeploymentConnectionClasses());
+        $this->assertArrayHasKey('local', $configuration->getDeploymentConnectionClasses());
+    }
 }

--- a/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
+++ b/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Accompli\Test;
+
+use Accompli\DependencyInjection\ConfigurationServiceRegistrationCompilerPass;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * ConfigurationServiceRegistrationCompilerPassTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if ConfigurationServiceRegistrationCompilerPass::process registers the configured deployment classes as service.
+     */
+    public function testProcess()
+    {
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())->method('getDeploymentStrategyClass')->willReturn(get_class($deploymentStrategyMock));
+        $configurationMock->expects($this->once())->method('getDeploymentConnectionClasses')->willReturn(array('local' => get_class($connectionMock)));
+
+        $container = new ContainerBuilder();
+        $container->set('configuration', $configurationMock);
+
+        $compilerPass = new ConfigurationServiceRegistrationCompilerPass();
+        $compilerPass->process($container);
+
+        $this->assertTrue($container->has('deployment_strategy'));
+        $this->assertTrue($container->has('local_connection'));
+    }
+
+    /**
+     * Tests if ConfigurationServiceRegistrationCompilerPass::process does nothing when no configuration service is registered.
+     */
+    public function testProcessDoesNothingWithoutRegisteredConfigurationService()
+    {
+        $container = new ContainerBuilder();
+
+        $compilerPass = new ConfigurationServiceRegistrationCompilerPass();
+        $compilerPass->process($container);
+
+        $this->assertFalse($container->has('deployment_strategy'));
+        $this->assertFalse($container->has('local_connection'));
+    }
+}

--- a/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
+++ b/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Accompli\Test;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * AbstractDeploymentStrategyTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if AbstractDeploymentStrategy::setConfiguration sets the configuration property of the class.
+     */
+    public function testSetConfiguration()
+    {
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
+
+        $deploymentStrategyMock->setConfiguration($configurationMock);
+
+        $this->assertAttributeSame($configurationMock, 'configuration', $deploymentStrategyMock);
+    }
+
+    /**
+     * Tests if AbstractDeploymentStrategy::setEventDispatcher sets the event dispatcher property of the class.
+     */
+    public function testSetEventDispatcher()
+    {
+        $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
+
+        $deploymentStrategyMock->setEventDispatcher($eventDispatcherMock);
+
+        $this->assertAttributeSame($eventDispatcherMock, 'eventDispatcher', $deploymentStrategyMock);
+    }
+}

--- a/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
+++ b/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Accompli\Test;
+
+use Accompli\AccompliEvents;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Strategy\RemoteInstallStrategy;
+use Accompli\Event\FailedEvent;
+use Accompli\Event\InstallReleaseEvent;
+use Accompli\Event\PrepareReleaseEvent;
+use Accompli\Event\PrepareWorkspaceEvent;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * RemoteInstallStrategyTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if RemoteInstallStrategy::install retrieves the hosts from the configuration through ConfigurationInterface::getHosts.
+     */
+    public function testInstallWithoutStageRetrievesHostsFromConfiguration()
+    {
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())->method('getHosts')->willReturn(array());
+        $configurationMock->expects($this->never())->method('getHostsByStage');
+
+        $strategy = new RemoteInstallStrategy();
+        $strategy->setConfiguration($configurationMock);
+        $strategy->install('0.1.0');
+    }
+
+    /**
+     * Tests if RemoteInstallStrategy::install retrieves the hosts from the configuration through ConfigurationInterface::getHostsByStage.
+     *
+     * @depends testInstallWithoutStageRetrievesHostsFromConfiguration
+     */
+    public function testInstallWithStageRetrievesHostsByStageFromConfiguration()
+    {
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())->method('getHosts')->willReturn(array());
+        $configurationMock->expects($this->once())
+                ->method('getHostsByStage')
+                ->with($this->equalTo(Host::STAGE_TEST))
+                ->willReturn(array());
+
+        $strategy = new RemoteInstallStrategy();
+        $strategy->setConfiguration($configurationMock);
+        $strategy->install('0.1.0', Host::STAGE_TEST);
+    }
+
+    /**
+     * Tests if RemoteInstallStrategy::install dispatches all the events successfully.
+     *
+     * @depends testInstallWithStageRetrievesHostsByStageFromConfiguration
+     */
+    public function testInstallDispatchesEventsSuccessfully()
+    {
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
+                ->getMock();
+
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getHostsByStage')
+                ->with($this->equalTo(Host::STAGE_TEST))
+                ->willReturn(array($hostMock));
+
+        $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock->expects($this->exactly(3))
+                ->method('dispatch')
+                ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
+                        $this->callback(array($this, 'provideDispatchCallbackForPrepareWorkspaceEvent')),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::PREPARE_RELEASE),
+                        $this->callback(array($this, 'provideDispatchCallbackForPrepareReleaseEvent')),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof InstallReleaseEvent);
+                        }),
+                    )
+                );
+
+        $strategy = new RemoteInstallStrategy();
+        $strategy->setConfiguration($configurationMock);
+        $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->install('0.1.0', Host::STAGE_TEST);
+    }
+
+    /**
+     * Tests if RemoteInstallStrategy::install dispatches all the events untill after the PrepareWorkspaceEvent.
+     *
+     * @depends testInstallDispatchesEventsSuccessfully
+     */
+    public function testInstallDispatchesEventsSuccessfullyUntillAfterPrepareWorkspaceEvent()
+    {
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
+                ->getMock();
+
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getHostsByStage')
+                ->with($this->equalTo(Host::STAGE_TEST))
+                ->willReturn(array($hostMock));
+
+        $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock->expects($this->exactly(3))
+                ->method('dispatch')
+                ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
+                        $this->callback(array($this, 'provideDispatchCallbackForPrepareWorkspaceEvent')),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::PREPARE_RELEASE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof PrepareReleaseEvent);
+                        }),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE_FAILED),
+                        $this->callback(function ($event) {
+                            return ($event instanceof FailedEvent);
+                        }),
+                    )
+                );
+
+        $strategy = new RemoteInstallStrategy();
+        $strategy->setConfiguration($configurationMock);
+        $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->install('0.1.0', Host::STAGE_TEST);
+    }
+
+    /**
+     * Tests if RemoteInstallStrategy::install dispatches all the events untill after the PrepareReleaseEvent.
+     *
+     * @depends testInstallDispatchesEventsSuccessfully
+     */
+    public function testInstallDispatchesEventsSuccessfullyUntillAfterPrepareReleaseEvent()
+    {
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
+                ->getMock();
+
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getHostsByStage')
+                ->with($this->equalTo(Host::STAGE_TEST))
+                ->willReturn(array($hostMock));
+
+        $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch')
+                ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof PrepareWorkspaceEvent);
+                        }),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE_FAILED),
+                        $this->callback(function ($event) {
+                            return ($event instanceof FailedEvent);
+                        }),
+                    )
+                );
+
+        $strategy = new RemoteInstallStrategy();
+        $strategy->setConfiguration($configurationMock);
+        $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->install('0.1.0', Host::STAGE_TEST);
+    }
+
+    /**
+     * Provides the dispatch test callback for the PrepareWorkspaceEvent.
+     *
+     * @see testInstallDispatchesEventsSuccessfully
+     *
+     * @param Event $event
+     *
+     * @return bool
+     */
+    public function provideDispatchCallbackForPrepareWorkspaceEvent(Event $event)
+    {
+        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+                ->setConstructorArgs(array($event->getHost()))
+                ->getMock();
+
+        $event->setWorkspace($workspaceMock);
+
+        return ($event instanceof PrepareWorkspaceEvent);
+    }
+
+    /**
+     * Provides the dispatch test callback for the PrepareReleaseEvent.
+     *
+     * @see testInstallDispatchesEventsSuccessfully
+     *
+     * @param Event $event
+     *
+     * @return bool
+     */
+    public function provideDispatchCallbackForPrepareReleaseEvent(Event $event)
+    {
+        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+                ->setConstructorArgs(array($event->getVersion()))
+                ->getMock();
+
+        $event->setRelease($releaseMock);
+
+        return ($event instanceof PrepareReleaseEvent);
+    }
+}

--- a/tests/Resources/accompli-with-mock-listeners.json
+++ b/tests/Resources/accompli-with-mock-listeners.json
@@ -14,5 +14,8 @@
         "listeners": {
             "listener_event": ["Accompli\\Test\\Mock\\EventListenerSubscriberMock::eventListener"]
         }
+    },
+    "deployment": {
+        "strategy": ""
     }
 }

--- a/tests/Resources/accompli.json
+++ b/tests/Resources/accompli.json
@@ -20,5 +20,8 @@
         "listeners": {
             "accompli.prepare_server": ["SomeTask::someAction"]
         }
+    },
+    "deployment": {
+        "strategy": ""
     }
 }


### PR DESCRIPTION
The deployment strategy implementation allows customization for both the install and deploy commands.
### Todo
- [x] Add test for Accompli::install
- [x] Add test for Accompli::deploy
- [x] Add unit tests for RemoteInstallStrategy
- [x] Add implementation for DeployReleaseCommand
