### PR TITLE
Added connection manager service implementation

### DIFF
--- a/src/AccompliEvents.php
+++ b/src/AccompliEvents.php
@@ -10,6 +10,16 @@ namespace Accompli;
 final class AccompliEvents
 {
     /**
+     * The CREATE_CONNECTION event is dispatched when a connection (connection adapter) needs to be created for a Host.
+     *
+     * The event listener receives an
+     * Accompli\Event\HostEvent instance.
+     *
+     * @var string
+     */
+    const CREATE_CONNECTION = 'accompli.create_connection';
+
+    /**
      * The DEPLOY_RELEASE event is dispatched when a Release is ready for deployment.
      *
      * The event listener receives an
@@ -137,6 +147,7 @@ final class AccompliEvents
     public static function getEventNames()
     {
         return array(
+            self::CREATE_CONNECTION,
             self::DEPLOY_RELEASE,
             self::DEPLOY_RELEASE_COMPLETE,
             self::DEPLOY_RELEASE_FAILED,

--- a/src/DependencyInjection/ConfigurationServiceRegistrationCompilerPass.php
+++ b/src/DependencyInjection/ConfigurationServiceRegistrationCompilerPass.php
@@ -3,6 +3,7 @@
 namespace Accompli\DependencyInjection;
 
 use Accompli\Configuration\ConfigurationInterface;
+use Accompli\Deployment\Connection\ConnectionManagerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -25,8 +26,11 @@ class ConfigurationServiceRegistrationCompilerPass implements CompilerPassInterf
         if ($configuration instanceof ConfigurationInterface) {
             $this->registerService($container, 'deployment_strategy', $configuration->getDeploymentStrategyClass());
 
-            foreach ($configuration->getDeploymentConnectionClasses() as $connectionId => $connectionClass) {
-                $this->registerService($container, $connectionId.'_connection', $connectionClass);
+            $connectionManager = $container->get('connection_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+            if ($connectionManager instanceof ConnectionManagerInterface) {
+                foreach ($configuration->getDeploymentConnectionClasses() as $connectionType => $connectionAdapterClass) {
+                    $connectionManager->registerConnectionAdapter($connectionType, $connectionAdapterClass);
+                }
             }
         }
     }

--- a/src/Deployment/Connection/ConnectionManager.php
+++ b/src/Deployment/Connection/ConnectionManager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Accompli\Deployment\Connection;
+
+use Accompli\Deployment\Host;
+use Nijens\Utilities\ObjectFactory;
+
+/**
+ * ConnectionManager.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ConnectionManager implements ConnectionManagerInterface
+{
+    /**
+     * The array with connection types and accompanying connection adapter classes.
+     *
+     * @var array
+     */
+    private $connectionAdapters = array();
+
+    /**
+     * The array with connection adapters.
+     *
+     * @var ConnectionAdapterInterface[]
+     */
+    private $connections = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerConnectionAdapter($connectionType, $connectionAdapterClass)
+    {
+        if (class_exists($connectionAdapterClass) && in_array('Accompli\Deployment\Connection\ConnectionAdapterInterface', class_implements($connectionAdapterClass))) {
+            $this->connectionAdapters[$connectionType] = $connectionAdapterClass;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectionAdapter(Host $host)
+    {
+        if (isset($this->connectionAdapters[$host->getConnectionType()])) {
+            $connectionIdentifier = spl_object_hash($host);
+
+            if (isset($this->connections[$connectionIdentifier]) === false) {
+                $connectionAdapterArguments = $host->getConnectionOptions();
+                $connectionAdapterArguments['hostname'] = $host->getHostname();
+
+                $this->connections[$connectionIdentifier] = ObjectFactory::getInstance()->newInstance($this->connectionAdapters[$host->getConnectionType()], $connectionAdapterArguments);
+            }
+
+            return $this->connections[$connectionIdentifier];
+        }
+    }
+}

--- a/src/Deployment/Connection/ConnectionManager.php
+++ b/src/Deployment/Connection/ConnectionManager.php
@@ -3,6 +3,7 @@
 namespace Accompli\Deployment\Connection;
 
 use Accompli\Deployment\Host;
+use Accompli\Event\HostEvent;
 use Nijens\Utilities\ObjectFactory;
 
 /**
@@ -52,6 +53,19 @@ class ConnectionManager implements ConnectionManagerInterface
             }
 
             return $this->connections[$connectionIdentifier];
+        }
+    }
+
+    /**
+     * Sets a connection adapter on a Host when an 'accompli.create_connection' event is dispatched.
+     *
+     * @param HostEvent $event
+     */
+    public function onCreateConnection(HostEvent $event)
+    {
+        $connectionAdapter = $this->getConnectionAdapter($event->getHost());
+        if ($connectionAdapter instanceof ConnectionAdapterInterface) {
+            $event->getHost()->setConnection($connectionAdapter);
         }
     }
 }

--- a/src/Deployment/Connection/ConnectionManagerInterface.php
+++ b/src/Deployment/Connection/ConnectionManagerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Accompli\Deployment\Connection;
+
+use Accompli\Deployment\Host;
+
+/**
+ * ConnectionManagerInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface ConnectionManagerInterface
+{
+    /**
+     * Registers a connection adapter classname for a connection type.
+     *
+     * @param string $connectionType
+     * @param string $connectionAdapterClass
+     */
+    public function registerConnectionAdapter($connectionType, $connectionAdapterClass);
+
+    /**
+     * Returns a connection adapter instance for a Host.
+     *
+     * @param Host $host
+     *
+     * @return ConnectionAdapterInterface|null
+     */
+    public function getConnectionAdapter(Host $host);
+}

--- a/src/Deployment/Host.php
+++ b/src/Deployment/Host.php
@@ -150,13 +150,23 @@ class Host
     }
 
     /**
-     * Returns the base workspace path of this host.
+     * Returns the base workspace path.
      *
      * @return string
      */
     public function getPath()
     {
         return $this->path;
+    }
+
+    /**
+     * Returns the connection options.
+     *
+     * @return array
+     */
+    public function getConnectionOptions()
+    {
+        return $this->connectionOptions;
     }
 
     /**

--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -6,6 +6,7 @@ use Accompli\AccompliEvents;
 use Accompli\Deployment\Release;
 use Accompli\Deployment\Workspace;
 use Accompli\Event\FailedEvent;
+use Accompli\Event\HostEvent;
 use Accompli\Event\InstallReleaseEvent;
 use Accompli\Event\PrepareReleaseEvent;
 use Accompli\Event\PrepareWorkspaceEvent;
@@ -28,6 +29,8 @@ class RemoteInstallStrategy extends AbstractDeploymentStrategy
         }
 
         foreach ($hosts as $host) {
+            $this->eventDispatcher->dispatch(AccompliEvents::CREATE_CONNECTION, new HostEvent($host));
+
             $prepareWorkspaceEvent = new PrepareWorkspaceEvent($host);
             $this->eventDispatcher->dispatch(AccompliEvents::PREPARE_WORKSPACE, $prepareWorkspaceEvent);
 

--- a/src/Event/HostEvent.php
+++ b/src/Event/HostEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Accompli\Event;
+
+use Accompli\Deployment\Host;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * HostEvent.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class HostEvent extends Event
+{
+    /**
+     * The Host instance.
+     *
+     * @var Host
+     */
+    private $host;
+
+    /**
+     * Constructs a new HostEvent.
+     *
+     * @param Host $host
+     */
+    public function __construct(Host $host)
+    {
+        $this->host = $host;
+    }
+
+    /**
+     * Returns the Host instance.
+     *
+     * @return Host
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+}

--- a/src/Event/PrepareWorkspaceEvent.php
+++ b/src/Event/PrepareWorkspaceEvent.php
@@ -2,40 +2,21 @@
 
 namespace Accompli\Event;
 
-use Accompli\Deployment\Host;
 use Accompli\Deployment\Workspace;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PrepareWorkspaceEvent.
  *
- * @author  Niels Nijens <nijens.niels@gmail.com>
+ * @author Niels Nijens <nijens.niels@gmail.com>
  */
-class PrepareWorkspaceEvent extends Event
+class PrepareWorkspaceEvent extends HostEvent
 {
-    /**
-     * The Host instance.
-     *
-     * @var Host
-     */
-    private $host;
-
     /**
      * The Workspace instance.
      *
      * @var Workspace
      */
     private $workspace;
-
-    /**
-     * Constructs a new PrepareWorkspaceEvent.
-     *
-     * @param Host $host
-     */
-    public function __construct(Host $host)
-    {
-        $this->host = $host;
-    }
 
     /**
      * Sets a Workspace instance.
@@ -45,16 +26,6 @@ class PrepareWorkspaceEvent extends Event
     public function setWorkspace(Workspace $workspace)
     {
         $this->workspace = $workspace;
-    }
-
-    /**
-     * Returns the Host instance.
-     *
-     * @return Host
-     */
-    public function getHost()
-    {
-        return $this->host;
     }
 
     /**

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -8,6 +8,8 @@ services:
         class: Accompli\Deployment\Connection\ConnectionManager
     event_dispatcher:
         class: Symfony\Component\EventDispatcher\EventDispatcher
+        calls:
+            - [addListener, [accompli.create_connection, ["@connection_manager", onCreateConnection]]]
     logger:
         class: Symfony\Component\Console\Logger\ConsoleLogger
         arguments: ["%console.output_interface%"]

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -4,6 +4,8 @@ services:
         class: Accompli\Configuration\Configuration
         calls:
             - [load, ["%configuration.file%"]]
+    connection_manager:
+        class: Accompli\Deployment\Connection\ConnectionManager
     event_dispatcher:
         class: Symfony\Component\EventDispatcher\EventDispatcher
     logger:

--- a/tests/AccompliTest.php
+++ b/tests/AccompliTest.php
@@ -171,6 +171,7 @@ class AccompliTest extends PHPUnit_Framework_TestCase
     {
         return array(
             array('configuration', 'Accompli\Configuration\ConfigurationInterface'),
+            array('connection_manager', 'Accompli\Deployment\Connection\ConnectionManagerInterface'),
             array('event_dispatcher', 'Symfony\Component\EventDispatcher\EventDispatcherInterface'),
             array('logger', 'Psr\Log\LoggerInterface'),
         );

--- a/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
+++ b/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
@@ -14,16 +14,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Tests if ConfigurationServiceRegistrationCompilerPass::process registers the configured deployment classes as service.
+     * Tests if ConfigurationServiceRegistrationCompilerPass::process registers the configured deployment strategy as service.
      */
-    public function testProcess()
+    public function testProcessAddsConfiguredDeploymentStrategyService()
     {
         $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
-        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
 
         $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
         $configurationMock->expects($this->once())->method('getDeploymentStrategyClass')->willReturn(get_class($deploymentStrategyMock));
-        $configurationMock->expects($this->once())->method('getDeploymentConnectionClasses')->willReturn(array('local' => get_class($connectionMock)));
 
         $container = new ContainerBuilder();
         $container->set('configuration', $configurationMock);
@@ -32,7 +30,30 @@ class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework
         $compilerPass->process($container);
 
         $this->assertTrue($container->has('deployment_strategy'));
-        $this->assertTrue($container->has('local_connection'));
+    }
+
+    /**
+     * Tests if ConfigurationServiceRegistrationCompilerPass::process registers the configured connection adapters with the connection manager service.
+     */
+    public function testProcessAddsConfiguredConnectionClassesToConnectionManager()
+    {
+        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionMockClass = get_class($connectionMock);
+
+        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock->expects($this->once())->method('getDeploymentConnectionClasses')->willReturn(array('local' => $connectionMockClass));
+
+        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManagerInterface')->getMock();
+        $connectionManagerMock->expects($this->once())
+                ->method('registerConnectionAdapter')
+                ->with($this->equalTo('local'), $this->equalTo($connectionMockClass));
+
+        $container = new ContainerBuilder();
+        $container->set('configuration', $configurationMock);
+        $container->set('connection_manager', $connectionManagerMock);
+
+        $compilerPass = new ConfigurationServiceRegistrationCompilerPass();
+        $compilerPass->process($container);
     }
 
     /**
@@ -40,12 +61,15 @@ class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework
      */
     public function testProcessDoesNothingWithoutRegisteredConfigurationService()
     {
+        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManagerInterface')->getMock();
+        $connectionManagerMock->expects($this->never())->method('registerConnectionAdapter');
+
         $container = new ContainerBuilder();
+        $container->set('connection_manager', $connectionManagerMock);
 
         $compilerPass = new ConfigurationServiceRegistrationCompilerPass();
         $compilerPass->process($container);
 
         $this->assertFalse($container->has('deployment_strategy'));
-        $this->assertFalse($container->has('local_connection'));
     }
 }

--- a/tests/Deployment/Connection/ConnectionManagerTest.php
+++ b/tests/Deployment/Connection/ConnectionManagerTest.php
@@ -4,6 +4,7 @@ namespace Accompli\Test;
 
 use Accompli\Deployment\Connection\ConnectionManager;
 use Accompli\Deployment\Host;
+use Accompli\Event\HostEvent;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -114,5 +115,23 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
         $returnedConnectionAdapter = $connectionManager->getConnectionAdapter($host);
 
         $this->assertNotSame($returnedConnectionAdapter, $connectionManager->getConnectionAdapter($hostTwo));
+    }
+
+    /**
+     * Tests if ConnectionManager::onCreateConnection listener method retrieves a connection adapter and sets it on the host.
+     */
+    public function testOnCreateConnection()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
+
+        $host = new Host('test', 'test', 'example.org', '');
+        $event = new HostEvent($host);
+
+        $connectionManager->onCreateConnection($event);
+
+        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $host->getConnection());
     }
 }

--- a/tests/Deployment/Connection/ConnectionManagerTest.php
+++ b/tests/Deployment/Connection/ConnectionManagerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Accompli\Test;
+
+use Accompli\Deployment\Connection\ConnectionManager;
+use Accompli\Deployment\Host;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * ConnectionManagerTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ConnectionManagerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if ConnectionManager::registerConnectionType registers connection adapter.
+     */
+    public function testRegisterConnectionTypeAddsValidConnectionAdapter()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
+
+        $this->assertAttributeEquals(array('test' => get_class($connectionAdapterMock)), 'connectionAdapters', $connectionManager);
+    }
+
+    /**
+     * Tests if ConnectionManager::registerConnectionType does not register the invalid connection adapter.
+     */
+    public function testRegisterConnectionTypeDoesNotAddInvalidConnectionAdapter()
+    {
+        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManager')->getMock();
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionManagerMock));
+
+        $this->assertAttributeEmpty('connectionAdapters', $connectionManager);
+    }
+
+    /**
+     * Tests if ConnectionManager::registerConnectionType does not register the non-existing connection adapter.
+     */
+    public function testRegisterConnectionTypeDoesNotAddNonExistingConnectionAdapter()
+    {
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', 'Accompli\Deployment\Connection\DoesNotExist');
+
+        $this->assertAttributeEmpty('connectionAdapters', $connectionManager);
+    }
+
+    /**
+     * Tests if ConnectionManager::getConnectionAdapter returns null when a connection adapter is not available.
+     */
+    public function testGetConnectionAdapterReturnsNullWhenConnectionAdapterForConnectionTypeIsNotAvailable()
+    {
+        $host = new Host('test', 'test', 'example.org', '');
+
+        $connectionManager = new ConnectionManager();
+
+        $this->assertNull($connectionManager->getConnectionAdapter($host));
+    }
+
+    /**
+     * Tests if ConnectionManager::getConnectionAdapter returns a connection adapter instance.
+     */
+    public function testGetConnectionAdapterReturnsConnectionAdapter()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $host = new Host('test', 'test', 'example.org', '');
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
+
+        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $connectionManager->getConnectionAdapter($host));
+    }
+
+    /**
+     * Tests if ConnectionManager::getConnectionAdapter returns the same connection adapter instance.
+     *
+     * @depends testGetConnectionAdapterReturnsConnectionAdapter
+     */
+    public function testGetConnectionAdapterAlwaysReturnsTheSameInstance()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $host = new Host('test', 'test', 'example.org', '');
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
+
+        $returnedConnectionAdapter = $connectionManager->getConnectionAdapter($host);
+
+        $this->assertSame($returnedConnectionAdapter, $connectionManager->getConnectionAdapter($host));
+    }
+
+    /**
+     * Tests if ConnectionManager::getConnectionAdapter does not return the same connection adapter instance for a different Host instance.
+     *
+     * @depends testGetConnectionAdapterReturnsConnectionAdapter
+     */
+    public function testGetConnectionAdapterDoesNotReturnTheSameInstanceForDifferentHost()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+
+        $host = new Host('test', 'test', 'example.org', '');
+        $hostTwo = new Host('test', 'test', 'example.org', '', array('connectionOption' => 'connectionOptionValue'));
+
+        $connectionManager = new ConnectionManager();
+        $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
+
+        $returnedConnectionAdapter = $connectionManager->getConnectionAdapter($host);
+
+        $this->assertNotSame($returnedConnectionAdapter, $connectionManager->getConnectionAdapter($hostTwo));
+    }
+}

--- a/tests/Deployment/HostTest.php
+++ b/tests/Deployment/HostTest.php
@@ -109,6 +109,7 @@ class HostTest extends PHPUnit_Framework_TestCase
             array('getConnectionType', 'local'),
             array('getHostname', 'localhost'),
             array('getPath', '/var/www'),
+            array('getConnectionOptions', array('connectionOptionKey' => 'connectionOptionValue')),
         );
     }
 
@@ -137,8 +138,8 @@ class HostTest extends PHPUnit_Framework_TestCase
      *
      * @return Host
      */
-    private function createHostInstance($stage = Host::STAGE_TEST, $connectionType = 'local', $hostname = 'localhost', $path = '/var/www')
+    private function createHostInstance($stage = Host::STAGE_TEST, $connectionType = 'local', $hostname = 'localhost', $path = '/var/www', $connectionOptions = array('connectionOptionKey' => 'connectionOptionValue'))
     {
-        return new Host($stage, $connectionType, $hostname, $path);
+        return new Host($stage, $connectionType, $hostname, $path, $connectionOptions);
     }
 }

--- a/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
+++ b/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
@@ -6,6 +6,7 @@ use Accompli\AccompliEvents;
 use Accompli\Deployment\Host;
 use Accompli\Deployment\Strategy\RemoteInstallStrategy;
 use Accompli\Event\FailedEvent;
+use Accompli\Event\HostEvent;
 use Accompli\Event\InstallReleaseEvent;
 use Accompli\Event\PrepareReleaseEvent;
 use Accompli\Event\PrepareWorkspaceEvent;
@@ -70,9 +71,15 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                 ->willReturn(array($hostMock));
 
         $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))
+        $eventDispatcherMock->expects($this->exactly(4))
                 ->method('dispatch')
                 ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::CREATE_CONNECTION),
+                        $this->callback(function ($event) {
+                            return ($event instanceof HostEvent);
+                        }),
+                    ),
                     array(
                         $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
                         $this->callback(array($this, 'provideDispatchCallbackForPrepareWorkspaceEvent')),
@@ -113,9 +120,15 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                 ->willReturn(array($hostMock));
 
         $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))
+        $eventDispatcherMock->expects($this->exactly(4))
                 ->method('dispatch')
                 ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::CREATE_CONNECTION),
+                        $this->callback(function ($event) {
+                            return ($event instanceof HostEvent);
+                        }),
+                    ),
                     array(
                         $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
                         $this->callback(array($this, 'provideDispatchCallbackForPrepareWorkspaceEvent')),
@@ -158,9 +171,15 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                 ->willReturn(array($hostMock));
 
         $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))
+        $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch')
                 ->withConsecutive(
+                    array(
+                        $this->equalTo(AccompliEvents::CREATE_CONNECTION),
+                        $this->callback(function ($event) {
+                            return ($event instanceof HostEvent);
+                        }),
+                    ),
                     array(
                         $this->equalTo(AccompliEvents::PREPARE_WORKSPACE),
                         $this->callback(function ($event) {


### PR DESCRIPTION
Added connection manager service implementation to be able to create connections and actually be able to do actions on a (remote) host within event listeners.

This PR adds the following:
- The connection manager service.
- A new 'accompli.create_connection' event.
- An event listener for 'accompli.create_connection' within the connection manager service which will  create connection adapters when possible.
- Implementation of the 'accompli.create_connection' event in the RemoteInstallStrategy.

This closes #25.
