### PR TITLE
Fixed RemoteInstallStrategy::install with multiple hosts for a stage

### DIFF
--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -44,7 +44,7 @@ class RemoteInstallStrategy extends AbstractDeploymentStrategy
                     $installReleaseEvent = new InstallReleaseEvent($release);
                     $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE, $installReleaseEvent);
 
-                    return;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
The current implementation of RemoteInstallStrategy::install stops after one succesful install run on a host. When multiple hosts are configured for a stage, then the next hosts will be 'skipped'.

The PR fixes this problem with the current implementation.
