### PR TITLE
Improved connection adapters

### DIFF
--- a/src/Deployment/Connection/ConnectionAdapterInterface.php
+++ b/src/Deployment/Connection/ConnectionAdapterInterface.php
@@ -24,6 +24,31 @@ interface ConnectionAdapterInterface
     public function disconnect();
 
     /**
+     * Returns true when the adapter is connected.
+     *
+     * @return bool
+     */
+    public function isConnected();
+
+    /**
+     * Returns true if $remoteFilename is a remote file.
+     *
+     * @param string $remoteFilename
+     *
+     * @return bool
+     */
+    public function isFile($remoteFilename);
+
+    /**
+     * Returns true if $remoteDirectory is a remote directory.
+     *
+     * @param string $remoteDirectory
+     *
+     * @return bool
+     */
+    public function isDirectory($remoteDirectory);
+
+    /**
      * Executes a command.
      *
      * @param string $command
@@ -33,61 +58,122 @@ interface ConnectionAdapterInterface
     public function executeCommand($command);
 
     /**
+     * Returns an array with files and directories within a remote directory.
+     *
+     * @param string $remoteDirectory
+     *
+     * @return array
+     */
+    public function getDirectoryContentsList($remoteDirectory);
+
+    /**
      * Returns the contents of a remote file.
      *
-     * @param string $filename
+     * @param string $remoteFilename
      *
      * @return string
      */
-    public function getContents($filename);
-
-    /**
-     * Set the $data to a file.
-     *
-     * @param string $destinationFilename
-     * @param mixed  $data
-     *
-     * @return bool
-     */
-    public function putContents($destinationFilename, $data);
+    public function getContents($remoteFilename);
 
     /**
      * Downloads a remote file to a local file.
      *
-     * @param string $sourceFilename
-     * @param string $destinationFilename
+     * @param string $remoteFilename
+     * @param string $localFilename
      *
      * @return bool
      */
-    public function getFile($sourceFilename, $destinationFilename);
+    public function getFile($remoteFilename, $localFilename);
 
     /**
-     * Uploads a local file to a remote file.
+     * Creates a remote directory.
      *
-     * @param string $sourceFilename
-     * @param string $destinationFilename
+     * @param string $remoteDirectory
+     * @param int    $fileMode
+     * @param bool   $recursive
      *
      * @return bool
      */
-    public function putFile($sourceFilename, $destinationFilename);
+    public function createDirectory($remoteDirectory, $fileMode = 0770, $recursive = false);
 
     /**
-     * Symlinks a remote file to a remote link.
+     * Creates an empty remote file.
      *
+     * @param string $remoteFilename
+     * @param int    $fileMode
+     *
+     * @return bool
+     */
+    public function createFile($remoteFilename, $fileMode = 0770);
+
+    /**
+     * Creates a symbolic link to an existing remote file or directory at a remote location.
+     *
+     * @param string $remoteSource
      * @param string $remoteTarget
-     * @param string $remoteLink
      *
      * @return bool
      */
-    public function linkFile($remoteTarget, $remoteLink);
+    public function link($remoteSource, $remoteTarget);
 
     /**
-     * Renames/moves a remote file or directory to another name or remote location.
+     * Moves/renames a remote file or directory to another name or remote location.
      *
      * @param string $remoteSource
      * @param string $remoteDestination
      *
      * @return bool
      */
-    public function renameFile($remoteSource, $remoteDestination);
+    public function move($remoteSource, $remoteDestination);
+
+    /**
+     * Copies a remote file or directory to another name or remote location.
+     *
+     * @param string $remoteSource
+     * @param string $remoteDestination
+     *
+     * @return bool
+     */
+    public function copy($remoteSource, $remoteDestination);
+
+    /**
+     * Changes the permissions of a remote file or directory.
+     *
+     * @param string $remoteTarget
+     * @param int    $fileMode
+     * @param bool   $recursive
+     *
+     * @return bool
+     */
+    public function changePermissions($remoteTarget, $fileMode, $recursive = false);
+
+    /**
+     * Sets the $data to a remote file.
+     *
+     * @param string $remoteFilename
+     * @param mixed  $data
+     *
+     * @return bool
+     */
+    public function putContents($remoteFilename, $data);
+
+    /**
+     * Uploads a local file to a remote file.
+     *
+     * @param string $localFilename
+     * @param string $remoteFilename
+     *
+     * @return bool
+     */
+    public function putFile($localFilename, $remoteFilename);
+
+    /**
+     * Deletes a remote file or directory.
+     *
+     * @param string $remoteTarget
+     * @param bool   $recursive
+     *
+     * @return bool
+     */
+    public function delete($remoteTarget, $recursive = false);
 }

--- a/src/Deployment/Connection/LocalConnectionAdapter.php
+++ b/src/Deployment/Connection/LocalConnectionAdapter.php
@@ -16,7 +16,7 @@ class LocalConnectionAdapter implements ConnectionAdapterInterface
      */
     public function connect()
     {
-        return true; // Does nothing
+        return true;
     }
 
     /**
@@ -24,7 +24,31 @@ class LocalConnectionAdapter implements ConnectionAdapterInterface
      */
     public function disconnect()
     {
-        return true; // Does nothing
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isConnected()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFile($remoteFilename)
+    {
+        return is_file($remoteFilename);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDirectory($remoteDirectory)
+    {
+        return is_dir($remoteDirectory);
     }
 
     /**
@@ -41,17 +65,96 @@ class LocalConnectionAdapter implements ConnectionAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getContents($filename)
+    public function getDirectoryContentsList($remoteDirectory)
     {
-        return file_get_contents($filename);
+        return array_values(array_diff(scandir($remoteDirectory, SCANDIR_SORT_ASCENDING), array('.', '..')));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function putContents($destinationFilename, $data)
+    public function getContents($remoteFilename)
     {
-        $result = file_put_contents($destinationFilename, $data);
+        return file_get_contents($remoteFilename);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFile($remoteFilename, $localFilename)
+    {
+        return $this->copy($remoteFilename, $localFilename);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDirectory($remoteDirectory, $fileMode = 0770, $recursive = false)
+    {
+        return mkdir($remoteDirectory, $fileMode, $recursive);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createFile($remoteFilename, $fileMode = 0770)
+    {
+        return (touch($remoteFilename) && $this->changePermissions($remoteFilename, $fileMode));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function link($remoteSource, $remoteTarget)
+    {
+        return symlink($remoteSource, $remoteTarget);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function move($remoteSource, $remoteDestination)
+    {
+        return rename($remoteSource, $remoteDestination);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy($remoteSource, $remoteDestination)
+    {
+        return copy($remoteSource, $remoteDestination);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function changePermissions($remoteTarget, $fileMode, $recursive = false)
+    {
+        if ($recursive === true && $this->isDirectory($remoteTarget)) {
+            $result = true;
+            $directoryItems = $this->getDirectoryContentsList($remoteTarget);
+            foreach ($directoryItems as $directoryItem) {
+                $directoryItem = $remoteTarget.'/'.$directoryItem;
+                if ($this->isDirectory($directoryItem)) {
+                    $result = ($result && $this->changePermissions($directoryItem, $fileMode, $recursive));
+                } else {
+                    $result = ($result && $this->changePermissions($directoryItem, $fileMode, false));
+                }
+            }
+
+            return ($result && $this->changePermissions($remoteTarget, $fileMode, false));
+        }
+
+        return chmod($remoteTarget, $fileMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function putContents($remoteFilename, $data)
+    {
+        $result = file_put_contents($remoteFilename, $data);
 
         return ($result !== false);
     }
@@ -59,32 +162,35 @@ class LocalConnectionAdapter implements ConnectionAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getFile($sourceFilename, $destinationFilename)
+    public function putFile($localFilename, $remoteFilename)
     {
-        return $this->putFile($sourceFilename, $destinationFilename);
+        return $this->copy($localFilename, $remoteFilename);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function putFile($sourceFilename, $destinationFilename)
+    public function delete($remoteTarget, $recursive = false)
     {
-        return copy($sourceFilename, $destinationFilename);
-    }
+        if ($recursive === true && $this->isDirectory($remoteTarget)) {
+            $result = true;
+            $directoryItems = $this->getDirectoryContentsList($remoteTarget);
+            foreach ($directoryItems as $directoryItem) {
+                $directoryItem = $remoteTarget.'/'.$directoryItem;
+                if ($this->isDirectory($directoryItem)) {
+                    $result = ($result && $this->delete($directoryItem, $recursive));
+                } else {
+                    $result = ($result && $this->delete($directoryItem, false));
+                }
+            }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function linkFile($remoteTarget, $remoteLink)
-    {
-        return symlink($remoteTarget, $remoteLink);
-    }
+            return ($result && $this->delete($remoteTarget, false));
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renameFile($remoteSource, $remoteDestination)
-    {
-        return rename($remoteSource, $remoteDestination);
+        if ($this->isDirectory($remoteTarget)) {
+            return rmdir($remoteTarget);
+        }
+
+        return unlink($remoteTarget);
     }
 }

--- a/tests/Deployment/Connection/ConnectedConnectionAdapterTestCase.php
+++ b/tests/Deployment/Connection/ConnectedConnectionAdapterTestCase.php
@@ -18,58 +18,162 @@ abstract class ConnectedConnectionAdapterTestCase extends ConnectionAdapterTestC
     }
 
     /**
+     * Tests if ConnectionAdapterInterface::isConnected returns false when not connected.
+     */
+    public function testIsConnectedReturnsFalseWhenNotConnected()
+    {
+        $this->assertFalse($this->connectionAdapter->isConnected());
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::isFile returns false when not connected.
+     */
+    public function testIsFileReturnsFalseWhenNotConnected()
+    {
+        $this->workspaceUtility->createFile('/test.txt');
+
+        $this->assertFalse($this->connectionAdapter->isFile($this->workspaceUtility->getWorkspacePath().'/test.txt'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::isDirectory returns false when not connected.
+     */
+    public function testIsDirectoryReturnsFalseWhenNotConnected()
+    {
+        $this->workspaceUtility->createDirectory('/existing-directory/');
+
+        $this->assertFalse($this->connectionAdapter->isDirectory($this->workspaceUtility->getWorkspacePath().'/existing-directory'));
+    }
+
+    /**
      * Tests if ConnectionAdapterInterface::executeCommand returns false without connection.
      */
-    public function testExecuteCommandReturnsFalseWithoutConnection()
+    public function testExecuteCommandReturnsFalseWhenNotConnected()
     {
         $this->assertFalse($this->connectionAdapter->executeCommand('echo test'));
     }
 
     /**
+     * Tests if ConnectionAdapterInterface::getDirectoryContentsList returns false without connection.
+     */
+    public function testGetDirectoryContentsListReturnsEmtpyArrayWhenNotConnected()
+    {
+        $this->workspaceUtility->createDirectory('/existing-directory/subdirectory', true);
+        $this->workspaceUtility->createFile('/existing-directory/test.txt');
+
+        $result = $this->connectionAdapter->getDirectoryContentsList($this->workspaceUtility->getWorkspacePath().'/existing-directory/');
+
+        $this->assertInternalType('array', $result);
+        $this->assertEmpty($result);
+    }
+
+    /**
      * Tests if ConnectionAdapterInterface::getContents returns false without connection.
      */
-    public function testGetContentsReturnsFalseWithoutConnection()
+    public function testGetContentsReturnsFalseWhenNotConnected()
     {
         $this->assertFalse($this->connectionAdapter->getContents(__DIR__.'/test.txt'));
     }
 
     /**
-     * Tests if ConnectionAdapterInterface::putContents returns false without connection.
-     */
-    public function testPutContentsReturnsFalseWithoutConnection()
-    {
-        $this->assertFalse($this->connectionAdapter->putContents(__DIR__.'/test.txt', 'test'));
-    }
-
-    /**
      * Tests if ConnectionAdapterInterface::getFile returns false without connection.
      */
-    public function testGetFileReturnsFalseWithoutConnection()
+    public function testGetFileReturnsFalseWhenNotConnected()
     {
         $this->assertFalse($this->connectionAdapter->getFile(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
     }
 
     /**
-     * Tests if ConnectionAdapterInterface::putFile returns false without connection.
+     * Tests if ConnectionAdapterInterface::createDirectory returns false without connection.
      */
-    public function testPutFileReturnsFalseWithoutConnection()
+    public function testCreateDirectoryReturnsFalseWhenNotConnected()
     {
-        $this->assertFalse($this->connectionAdapter->putFile(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
+        $this->assertFalse($this->connectionAdapter->createDirectory($this->workspaceUtility->getWorkspacePath().'/existing-directory'));
+        $this->assertFalse(is_dir($this->workspaceUtility->getWorkspacePath().'/existing-directory'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::createFile returns false without connection.
+     */
+    public function testCreateFileReturnsFalseWhenNotConnected()
+    {
+        $this->assertFalse($this->connectionAdapter->createFile($this->workspaceUtility->getWorkspacePath().'/test.txt'));
+        $this->assertFileNotExists($this->workspaceUtility->getWorkspacePath().'/test.txt');
     }
 
     /**
      * Tests if ConnectionAdapterInterface::linkFile returns false without connection.
      */
-    public function testLinkFileReturnsFalseWithoutConnection()
+    public function testLinkReturnsFalseWhenNotConnected()
     {
-        $this->assertFalse($this->connectionAdapter->linkFile(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
+        $this->assertFalse($this->connectionAdapter->link(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
     }
 
     /**
      * Tests if ConnectionAdapterInterface::renameFile returns false without connection.
      */
-    public function testRenameFileReturnsFalseWithoutConnection()
+    public function testMoveReturnsFalseWhenNotConnected()
     {
-        $this->assertFalse($this->connectionAdapter->renameFile(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
+        $this->assertFalse($this->connectionAdapter->move(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::copy returns false without connection.
+     */
+    public function testCopyReturnsFalseWhenNotConnected()
+    {
+        $this->workspaceUtility->createFile('/test.txt');
+
+        $this->assertFalse($this->connectionAdapter->copy($this->workspaceUtility->getWorkspacePath().'/test.txt', $this->workspaceUtility->getWorkspacePath().'/test2.txt'));
+        $this->assertFileNotExists($this->workspaceUtility->getWorkspacePath().'/test2.txt');
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::copy returns false when remote source is not available.
+     */
+    public function testCopyReturnsFalseWhenRemoteSourceNotAvailable()
+    {
+        $this->connectionAdapter->connect();
+
+        $this->assertFalse($this->connectionAdapter->copy($this->workspaceUtility->getWorkspacePath().'/test.txt', $this->workspaceUtility->getWorkspacePath().'/test2.txt'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::changeFileMode returns false without connection.
+     */
+    public function testChangePermissionsReturnsFalseWhenNotConnected()
+    {
+        $this->workspaceUtility->createFile('/test.txt');
+
+        $this->assertFalse($this->connectionAdapter->changePermissions($this->workspaceUtility->getWorkspacePath().'/test.txt', 0700));
+        $this->assertNotSame('0700', substr(sprintf('%o', fileperms($this->workspaceUtility->getWorkspacePath().'/test.txt')), -4));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::putContents returns false without connection.
+     */
+    public function testPutContentsReturnsFalseWhenNotConnected()
+    {
+        $this->assertFalse($this->connectionAdapter->putContents(__DIR__.'/test.txt', 'test'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::putFile returns false without connection.
+     */
+    public function testPutFileReturnsFalseWhenNotConnected()
+    {
+        $this->assertFalse($this->connectionAdapter->putFile(__DIR__.'/test.txt', __DIR__.'/test2.txt'));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::delete returns false without connection.
+     */
+    public function testDeleteWhenNotConnected()
+    {
+        $this->workspaceUtility->createDirectory('/existing-directory/subdirectory', true);
+        $this->workspaceUtility->createFile('/existing-directory/test.txt');
+
+        $this->assertFalse($this->connectionAdapter->delete($this->workspaceUtility->getWorkspacePath().'/existing-directory', true));
+        $this->assertFileExists($this->workspaceUtility->getWorkspacePath().'/existing-directory');
     }
 }

--- a/tests/Deployment/Connection/SSHConnectionAdapterTest.php
+++ b/tests/Deployment/Connection/SSHConnectionAdapterTest.php
@@ -57,6 +57,19 @@ class SSHConnectionAdapterTest extends ConnectedConnectionAdapterTestCase
     }
 
     /**
+     * Tests if SSHConnectionAdapter::connect returns true, but does not recreate the connection.
+     */
+    public function testCallingConnectTwiceDoesNotRecreateConnection()
+    {
+        $this->connectionAdapter->connect();
+
+        $connection = $this->getObjectAttribute($this->connectionAdapter, 'connection');
+
+        $this->assertTrue($this->connectionAdapter->connect());
+        $this->assertAttributeSame($connection, 'connection', $this->connectionAdapter);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function createConnectionAdapter()

--- a/tests/WorkspaceUtility.php
+++ b/tests/WorkspaceUtility.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Accompli\Test;
+
+/**
+ * WorkspaceUtility.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class WorkspaceUtility
+{
+    /**
+     * The path to the workspace.
+     *
+     * @var string
+     */
+    private $workspacePath;
+
+    /**
+     * Constructs a new WorkspaceUtility.
+     *
+     * @param string|null $workspacePath
+     */
+    public function __construct($workspacePath = null)
+    {
+        if ($workspacePath === null) {
+            $workspacePath = __DIR__.'/../test-workspace/';
+        }
+
+        $this->workspacePath = $workspacePath;
+    }
+
+    /**
+     * Returns the path to the workspace.
+     *
+     * @return string
+     */
+    public function getWorkspacePath()
+    {
+        return $this->workspacePath;
+    }
+
+    /**
+     * Creates the workspace directory.
+     */
+    public function create()
+    {
+        if (is_dir($this->workspacePath) === false) {
+            mkdir($this->workspacePath);
+        }
+    }
+
+    /**
+     * Creates a file with the workspace.
+     *
+     * @param string $filename
+     * @param string $data
+     */
+    public function createFile($filename, $data = '')
+    {
+        file_put_contents($this->workspacePath.$filename, $data);
+    }
+
+    /**
+     * Creates a directory with the workspace.
+     *
+     * @param string $directory
+     * @param bool   $recursive
+     */
+    public function createDirectory($directory, $recursive = false)
+    {
+        mkdir($this->workspacePath.$directory, 0770, $recursive);
+    }
+
+    /**
+     * Removes the workspace.
+     */
+    public function remove()
+    {
+        $this->removeItem($this->workspacePath);
+    }
+
+    /**
+     * Removes an item by $path.
+     *
+     * @param string $path
+     */
+    private function removeItem($path)
+    {
+        if (is_dir($path)) {
+            $directoryItems = array_diff(scandir($path), array('.', '..'));
+            foreach ($directoryItems as $directoryItem) {
+                $this->removeItem($path.'/'.$directoryItem);
+            }
+
+            rmdir($path);
+
+            return;
+        }
+
+        unlink($path);
+    }
+}


### PR DESCRIPTION
Expanded the API of the connection adapters and improved naming of arguments for a more clear API.

The following methods are added:
- isConnected
- isFile
- isDirectory
- getDirectoryContectsList
- createDirectory
- createFile
- copy
- changePermissions
- delete

The following methods are renamed:
- linkFile -> link
- renameFile -> move
