### PR TITLE
Added AbstractConnectedTask

### DIFF
--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Accompli\Exception;
+
+use RuntimeException;
+
+/**
+ * ConnectionException.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ConnectionException extends RuntimeException
+{
+}

--- a/src/Task/AbstractConnectedTask.php
+++ b/src/Task/AbstractConnectedTask.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Accompli\Task;
+
+use Accompli\Deployment\Host;
+use Accompli\Exception\ConnectionException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * AbstractConnectedTask.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+abstract class AbstractConnectedTask implements EventSubscriberInterface
+{
+    /**
+     * Ensures a connected connection adapter for a host.
+     * Returns the connection adapter instance.
+     *
+     * @param Host $host
+     *
+     * @return ConnectionAdapterInterface
+     *
+     * @throws ConnectionException
+     */
+    public function ensureConnection(Host $host)
+    {
+        if ($host->hasConnection()) {
+            $connection = $host->getConnection();
+            if ($connection->isConnected() === false && $connection->connect() === false) {
+                throw new ConnectionException(sprintf('Could not connect to "%s" through "%s".', $host->getHostname(), $host->getConnectionType()));
+            }
+
+            return $connection;
+        }
+
+        throw new ConnectionException(sprintf('No connection adapter of type "%s" found on host.', $host->getConnectionType()));
+    }
+}

--- a/tests/Task/AbstractConnectedTaskTest.php
+++ b/tests/Task/AbstractConnectedTaskTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Accompli\Test;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * AbstractConnectedTaskTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class AbstractConnectedTaskTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if AbstractConnectedTask::ensureConnection returns a connection adapter instance when connected.
+     */
+    public function testEnsureConnectionReturnsConnectionAdapterWhenConnected()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
+        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+
+        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+
+        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $task->ensureConnection($hostMock));
+    }
+
+    /**
+     * Tests if AbstractConnectedTask::ensureConnection returns a connection adapter instance when not connected but able to connect.
+     */
+    public function testEnsureConnectionReturnsConnectionAdapterWhenAbleToConnect()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(false);
+        $connectionAdapterMock->expects($this->once())->method('connect')->willReturn(true);
+
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
+        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+
+        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+
+        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $task->ensureConnection($hostMock));
+    }
+
+    /**
+     * Tests if AbstractConnectedTask::ensureConnection throws a ConnectionException when the connection adapter is not connected and not able to connect.
+     *
+     * @expectedException        Accompli\Exception\ConnectionException
+     * @expectedExceptionMessage Could not connect to "accompli.deployment.net" through "test".
+     */
+    public function testEnsureConnectionThrowsConnectionExceptionWhenNotConnectedAndNotAbleToConnect()
+    {
+        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(false);
+        $connectionAdapterMock->expects($this->once())->method('connect')->willReturn(false);
+
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
+        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())->method('getHostname')->willReturn('accompli.deployment.net');
+        $hostMock->expects($this->once())->method('getConnectionType')->willReturn('test');
+
+        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task->ensureConnection($hostMock);
+    }
+
+    /**
+     * Tests if AbstractConnectedTask::ensureConnection throws a ConnectionException when a connection adapter is not available on the Host instance.
+     *
+     * @expectedException        Accompli\Exception\ConnectionException
+     * @expectedExceptionMessage No connection adapter of type "test" found on host.
+     */
+    public function testEnsureConnectionThrowsConnectionExceptionWhenNoConnectionAdapterAvailable()
+    {
+        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $hostMock->expects($this->once())->method('hasConnection')->willReturn(false);
+        $hostMock->expects($this->once())->method('getConnectionType')->willReturn('test');
+
+        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task->ensureConnection($hostMock);
+    }
+}


### PR DESCRIPTION
Created AbstractConnectedTask to easily ensure a connection adapter connection when creating tasks on top of it.

Related PR: #48 
