### PR TITLE
Added AccompliEvents::INSTALL_RELEASE_COMPLETE and implemented in deployment strategy

### DIFF
--- a/src/AccompliEvents.php
+++ b/src/AccompliEvents.php
@@ -70,6 +70,16 @@ final class AccompliEvents
     const INSTALL_RELEASE = 'accompli.install_release';
 
     /**
+     * The INSTALL_RELEASE_COMPLETE event is dispatched when a Release is successfully installed.
+     *
+     * The event listener receives an
+     * Accompli\EventDispatcher\Event\InstallReleaseEvent instance.
+     *
+     * @var string
+     **/
+    const INSTALL_RELEASE_COMPLETE = 'accompli.install_release_complete';
+
+    /**
      * The INSTALL_RELEASE_FAILED event is dispatched when installation of a Release has failed.
      *
      * The event listener receives an
@@ -163,6 +173,7 @@ final class AccompliEvents
             self::DEPLOY_RELEASE_FAILED,
             self::GATHER_FACTS,
             self::INSTALL_RELEASE,
+            self::INSTALL_RELEASE_COMPLETE,
             self::INSTALL_RELEASE_FAILED,
             self::LOG,
             self::PREPARE_DEPLOY_RELEASE,

--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -48,6 +48,8 @@ class RemoteInstallStrategy extends AbstractDeploymentStrategy
                         $installReleaseEvent = new InstallReleaseEvent($release);
                         $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE, $installReleaseEvent);
 
+                        $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE_COMPLETE, $installReleaseEvent);
+
                         continue;
                     }
                 }

--- a/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
+++ b/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
@@ -71,7 +71,7 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                 ->willReturn(array($hostMock));
 
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(4))
+        $eventDispatcherMock->expects($this->exactly(5))
                 ->method('dispatch')
                 ->withConsecutive(
                     array(
@@ -90,6 +90,12 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     ),
                     array(
                         $this->equalTo(AccompliEvents::INSTALL_RELEASE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof InstallReleaseEvent);
+                        }),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE_COMPLETE),
                         $this->callback(function ($event) {
                             return ($event instanceof InstallReleaseEvent);
                         }),
@@ -119,7 +125,7 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                 ->willReturn(array($hostMock, $hostMock));
 
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(8))
+        $eventDispatcherMock->expects($this->exactly(10))
                 ->method('dispatch')
                 ->withConsecutive(
                     array(
@@ -143,6 +149,12 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                         }),
                     ),
                     array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE_COMPLETE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof InstallReleaseEvent);
+                        }),
+                    ),
+                    array(
                         $this->equalTo(AccompliEvents::CREATE_CONNECTION),
                         $this->callback(function ($event) {
                             return ($event instanceof HostEvent);
@@ -158,6 +170,12 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     ),
                     array(
                         $this->equalTo(AccompliEvents::INSTALL_RELEASE),
+                        $this->callback(function ($event) {
+                            return ($event instanceof InstallReleaseEvent);
+                        }),
+                    ),
+                    array(
+                        $this->equalTo(AccompliEvents::INSTALL_RELEASE_COMPLETE),
                         $this->callback(function ($event) {
                             return ($event instanceof InstallReleaseEvent);
                         }),


### PR DESCRIPTION
- Added AccompliEvents::INSTALL_RELEASE_COMPLETE event constant.
- Implemented AccompliEvents::INSTALL_RELEASE_COMPLETE in RemoteInstallStrategy.

Closes #60.
