### PR TITLE
Updated EventDispatcherAwareInterface to use Accompli\EventDispatcher\EventDispatcherInterface

### DIFF
--- a/src/DependencyInjection/EventDispatcherAwareInterface.php
+++ b/src/DependencyInjection/EventDispatcherAwareInterface.php
@@ -2,7 +2,7 @@
 
 namespace Accompli\DependencyInjection;
 
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 
 /**
  * EventDispatcherAwareInterface.

--- a/src/Deployment/Strategy/AbstractDeploymentStrategy.php
+++ b/src/Deployment/Strategy/AbstractDeploymentStrategy.php
@@ -5,7 +5,7 @@ namespace Accompli\Deployment\Strategy;
 use Accompli\Configuration\ConfigurationInterface;
 use Accompli\DependencyInjection\ConfigurationAwareInterface;
 use Accompli\DependencyInjection\EventDispatcherAwareInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 
 /**
  * AbstractDeploymentStrategy.

--- a/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
+++ b/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
@@ -29,7 +29,7 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testSetEventDispatcher()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
         $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
 
         $deploymentStrategyMock->setEventDispatcher($eventDispatcherMock);


### PR DESCRIPTION
The extended `EventDispatcherInterface` used by the `RemoteInstallStrategy` (see #32) wasn't changed in the `EventDispatcherAwareInterface`. Exposing the stategy class to be injected with a non-extended EventDispatcher and trigger a method not found error.

This PR updates the `EventDispatcherAwareInterface`.
