### PR TITLE
Improvements to CreateWorkspaceTask

### DIFF
--- a/src/Task/CreateWorkspaceTask.php
+++ b/src/Task/CreateWorkspaceTask.php
@@ -55,6 +55,9 @@ class CreateWorkspaceTask extends AbstractConnectedTask
                 array('onPrepareWorkspaceConstructWorkspaceInstance', 10),
                 array('onPrepareWorkspaceCreateWorkspace', 0),
             ),
+            AccompliEvents::GET_WORKSPACE => array(
+                array('onPrepareWorkspaceConstructWorkspaceInstance', 10),
+            ),
         );
     }
 

--- a/src/Task/CreateWorkspaceTask.php
+++ b/src/Task/CreateWorkspaceTask.php
@@ -130,13 +130,13 @@ class CreateWorkspaceTask extends AbstractConnectedTask
         foreach ($directories as $directory) {
             $context = array('directory' => $directory, 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS);
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Creating directory "{directory}".', $eventName, $this, $context));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Creating directory "{directory}".', $eventName, $this, $context));
             if ($connection->isDirectory($directory) === false) {
                 if ($connection->createDirectory($directory)) {
                     $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                     $context['output.resetLine'] = true;
 
-                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Created directory "{directory}".', $eventName, $this, $context));
+                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Created directory "{directory}".', $eventName, $this, $context));
                 } else {
                     $context['event.task.action'] = TaskInterface::ACTION_FAILED;
                     $context['output.resetLine'] = true;
@@ -147,7 +147,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
                 $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                 $context['output.resetLine'] = true;
 
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Directory "{directory}" exists.', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Directory "{directory}" exists.', $eventName, $this, $context));
             }
         }
     }

--- a/tests/Task/CreateWorkspaceTaskTest.php
+++ b/tests/Task/CreateWorkspaceTaskTest.php
@@ -16,12 +16,13 @@ use RuntimeException;
 class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Tests if CreateWorkspaceTask::getSubscribedEvents returns an array with at least a AccompliEvents::PREPARE_WORKSPACE key.
+     * Tests if CreateWorkspaceTask::getSubscribedEvents returns an array with at least a AccompliEvents::PREPARE_WORKSPACE and AccompliEvents::GET_WORKSPACE key.
      */
     public function testGetSubscribedEvents()
     {
         $this->assertInternalType('array', CreateWorkspaceTask::getSubscribedEvents());
         $this->assertArrayHasKey(AccompliEvents::PREPARE_WORKSPACE, CreateWorkspaceTask::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::GET_WORKSPACE, CreateWorkspaceTask::getSubscribedEvents());
     }
 
     /**


### PR DESCRIPTION
- Subscribed to `AccompliEvents::GET_WORKSPACE` to create the Workspace instance during deploying a release as well.
- Changed log message for creating directories to debug level.
