### PR TITLE
Fixed documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Accompli is licensed under the MIT License. Please see the [LICENSE file](LICENS
 [link-coverage]: https://coveralls.io/r/accompli/accompli?branch=master
 [link-security]: https://insight.sensiolabs.com/projects/5b884e85-bb11-4847-b212-e3aaace39a26
 [link-code-style]: https://styleci.io/repos/32416744
-[link-documentation]: https://github.com/accompli/accompli/docs/Getting-started.md
+[link-documentation]: https://github.com/accompli/accompli/blob/master/docs/01-Getting-started.md
 [link-author]: https://github.com/niels-nijens
 [link-author-name]: https://github.com/reyostallenberg
 [link-contributors]: https://github.com/accompli/accompli/contributors

--- a/docs/01-Getting-started.md
+++ b/docs/01-Getting-started.md
@@ -70,9 +70,9 @@ An example accompli.json:
 }
 ```
 
-For more detailed information on how to configure your accompli.json, please see the [configuration](Configuration.md) documentation.
+For more detailed information on how to configure your accompli.json, please see the [configuration](02-Configuration.md) documentation.
 
-See the [tasks](Tasks.md) documentation to learn what tasks are provided by Accompli and how to create your own tasks.
+See the [tasks](03-Tasks.md) documentation to learn what tasks are provided by Accompli and how to create your own tasks.
 
 ### Install a release for deployment
 To install a release for deployment you need to run the following command from your project root:

--- a/docs/02-Configuration.md
+++ b/docs/02-Configuration.md
@@ -38,7 +38,7 @@ A host object requires the following keys:
 
 Optionally, a 'connectionOptions' key can be configured within a host object with an array of connection adapter specific configuration parameters.
 
-For more information on the specific connection options, please see the [connection adapter](Connection-adapters.md) documentation.
+For more information on the specific connection options, please see the [connection adapter](04-Connection-adapters.md) documentation.
 
 ## Configuring a task
 
@@ -74,7 +74,7 @@ If your task has constructor arguments to configure it's behavior, you're able t
 }
 ```
 
-For more information about tasks and a list of available Accompli tasks, see the [tasks](Tasks.md) documentation.
+For more information about tasks and a list of available Accompli tasks, see the [tasks](03-Tasks.md) documentation.
 
 ## Configuring the deployment strategy
 


### PR DESCRIPTION
Fixed links to other documentation pages. They were forgotten when renaming the files.
