### PR TITLE
Fix extending from a recipe in Configuration

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -156,7 +156,11 @@ class Configuration implements ConfigurationInterface
     {
         $configuration = json_decode($json, true);
         if (isset($configuration['$extend'])) {
-            $extendConfigurationFile = sprintf('%s/%s', dirname($this->configurationFile), $configuration['$extend']);
+            $extendConfigurationFile = $configuration['$extend'];
+            $extendConfigurationFileScheme = parse_url($extendConfigurationFile, PHP_URL_SCHEME);
+            if (substr($extendConfigurationFile, 0, 1) === '/' || isset($extendConfigurationFileScheme) === false) {
+                $extendConfigurationFile = sprintf('%s/%s', dirname($this->configurationFile), $configuration['$extend']);
+            }
             unset($configuration['$extend']);
 
             $parentConfiguration = new static($extendConfigurationFile, $this->configurationSchema);

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -2,18 +2,29 @@
 
 namespace Accompli\Test;
 
+use Accompli\Accompli;
 use Accompli\Configuration\Configuration;
 use Accompli\Deployment\Host;
+use Nijens\ProtocolStream\Stream\Stream;
+use Nijens\ProtocolStream\StreamManager;
 use PHPUnit_Framework_TestCase;
 use UnexpectedValueException;
 
 /**
  * ConfigurationTest.
  *
- * @author  Niels Nijens <nijens.niels@gmail.com>
+ * @author Niels Nijens <nijens.niels@gmail.com>
  */
 class ConfigurationTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * Unregisters the accompli stream wrapper.
+     */
+    public function tearDown()
+    {
+        StreamManager::create()->unregisterStream('accompli');
+    }
+
     /**
      * testLoadWithValidJSON.
      */
@@ -65,6 +76,21 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $configuration->load(__DIR__.'/../Resources/accompli-extended.json');
 
         $this->assertArrayHasKey('deployment', $configuration->toArray());
+    }
+
+    /**
+     * Tests if Configuration::load imports the configuration extend through the accompli stream wrapper.
+     */
+    public function testLoadWithExtendedConfigurationFromRecipe()
+    {
+        $stream = new Stream('accompli', array(
+                'recipe' => realpath(__DIR__.'/../../src/Resources/recipe'),
+            ), false);
+
+        StreamManager::create()->registerStream($stream);
+
+        $configuration = new Configuration();
+        $configuration->load(__DIR__.'/../Resources/accompli-extended-recipe.json');
     }
 
     /**

--- a/tests/Resources/accompli-extended-recipe.json
+++ b/tests/Resources/accompli-extended-recipe.json
@@ -1,0 +1,25 @@
+{
+    "$extend": "accompli://recipe/defaults.json",
+    "hosts": [
+        {
+            "stage": "test",
+            "connectionType": "local",
+            "hostname": "",
+            "path": ""
+        }
+    ],
+    "events": {
+        "subscribers": [
+            "SetupTask",
+            {
+                "class": "ComposerTask",
+                "options": [
+                    "ignore-platform-reqs"
+                ]
+            }
+        ],
+        "listeners": {
+            "accompli.prepare_server": ["SomeTask::someAction"]
+        }
+    }
+}


### PR DESCRIPTION
The implemented stream wrapper (#107) missed implementation (and testing) for the stream wrapper in the `Configuration` class. This PR fixes this.
