### PR TITLE
Made SSHConnectionAdapter::executeCommand stateful

### DIFF
--- a/src/Deployment/Connection/SSHConnectionAdapter.php
+++ b/src/Deployment/Connection/SSHConnectionAdapter.php
@@ -175,6 +175,8 @@ class SSHConnectionAdapter implements ConnectionAdapterInterface
     public function changeWorkingDirectory($remoteDirectory)
     {
         if ($this->isConnected()) {
+            $this->executeCommand('cd', array($remoteDirectory));
+
             return $this->connection->chdir($remoteDirectory);
         }
 

--- a/src/Deployment/Connection/SSHConnectionAdapter.php
+++ b/src/Deployment/Connection/SSHConnectionAdapter.php
@@ -188,14 +188,23 @@ class SSHConnectionAdapter implements ConnectionAdapterInterface
     {
         if ($this->isConnected()) {
             $this->connection->enableQuietMode();
+            $this->connection->setTimeout(0);
 
             if (empty($arguments) === false) {
                 $command = ProcessUtility::escapeArguments($arguments, $command);
             }
 
-            $output = $this->connection->exec($command);
-            $exitCode = $this->connection->getExitStatus();
-            $errorOutput = $this->connection->getStdError();
+            if (isset($this->connection->server_channels[SFTP::CHANNEL_SHELL]) === false) {
+                $this->connection->read($this->getShellPromptRegex(), SFTP::READ_REGEX);
+            }
+
+            $this->connection->write($command."\n");
+            $output = $this->getFilteredOutput($this->connection->read($this->getShellPromptRegex(), SFTP::READ_REGEX), $command);
+
+            $this->connection->write("echo $?\n");
+
+            $exitCode = intval($this->getFilteredOutput($this->connection->read($this->getShellPromptRegex(), SFTP::READ_REGEX), 'echo $?'));
+            $errorOutput = strval($this->connection->getStdError());
 
             $this->connection->disableQuietMode();
 
@@ -410,5 +419,59 @@ class SSHConnectionAdapter implements ConnectionAdapterInterface
         $userDirectory .= '/'.$this->authenticationUsername;
 
         return $userDirectory;
+    }
+
+    /**
+     * Returns the filtered output of the command.
+     * Removes the command echo and shell prompt from the output.
+     *
+     * @param string $output
+     * @param string $command
+     *
+     * @return string
+     */
+    private function getFilteredOutput($output, $command)
+    {
+        $output = str_replace(array("\r\n", "\r"), array("\n", ''), $output);
+
+        $matches = array();
+        if (preg_match($this->getOutputFilterRegex($command), $output, $matches) === 1) {
+            $output = ltrim($matches[1]);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Returns the output filter regex to filter the output.
+     *
+     * @param string $command
+     *
+     * @return string
+     */
+    private function getOutputFilterRegex($command)
+    {
+        $commandCharacters = str_split(preg_quote($command, '/'));
+        $commandCharacterRegexWhitespaceFunction = function ($value) {
+            if ($value !== '\\') {
+                $value .= '\s?';
+            }
+
+            return $value;
+        };
+
+        $commandCharacters = array_map($commandCharacterRegexWhitespaceFunction, $commandCharacters);
+
+        return sprintf('/%s(.*)%s/s', implode('', $commandCharacters), substr($this->getShellPromptRegex(), 1, -1));
+    }
+
+    /**
+     * Returns the regex matching the shell prompt.
+     *
+     * @return string
+     */
+    private function getShellPromptRegex()
+    {
+        return sprintf('/%s@.*[$|#]/', $this->authenticationUsername);
     }
 }

--- a/tests/Deployment/Connection/ConnectionAdapterTestCase.php
+++ b/tests/Deployment/Connection/ConnectionAdapterTestCase.php
@@ -172,30 +172,6 @@ abstract class ConnectionAdapterTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests if ConnectionAdapterInterface::changeWorkingDirectory returns true on successful change to a different working directory.
-     *
-     * @depends testConnectReturnsTrue
-     */
-    public function testChangeWorkingDirectoryReturnsTrue()
-    {
-        $this->connectionAdapter->connect();
-
-        $this->assertTrue($this->connectionAdapter->changeWorkingDirectory($this->workspaceUtility->getWorkspacePath()));
-    }
-
-    /**
-     * Tests if ConnectionAdapterInterface::changeWorkingDirectory returns false when trying to change to a non-existing working directory.
-     *
-     * @depends testChangeWorkingDirectoryReturnsTrue
-     */
-    public function testChangeWorkingDirectoryWithNonExistingDirectoryReturnsFalse()
-    {
-        $this->connectionAdapter->connect();
-
-        $this->assertFalse($this->connectionAdapter->changeWorkingDirectory($this->workspaceUtility->getWorkspacePath().'/non-existing-directory'));
-    }
-
-    /**
      * Tests if ConnectionAdapterInterface::executeCommand returns the expected output.
      *
      * @depends testDisconnectReturnsTrue
@@ -225,6 +201,32 @@ abstract class ConnectionAdapterTestCase extends PHPUnit_Framework_TestCase
         $this->assertSame(0, $result->getExitCode());
         $this->assertSame('test'.PHP_EOL, $result->getOutput());
         $this->assertSame('', $result->getErrorOutput());
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::changeWorkingDirectory returns true on successful change to a different working directory.
+     *
+     * @depends testConnectReturnsTrue
+     * @depends testExecuteCommand
+     */
+    public function testChangeWorkingDirectoryReturnsTrue()
+    {
+        $this->connectionAdapter->connect();
+
+        $this->assertTrue($this->connectionAdapter->changeWorkingDirectory($this->workspaceUtility->getWorkspacePath()));
+        $this->assertSame(realpath($this->workspaceUtility->getWorkspacePath()), trim($this->connectionAdapter->executeCommand('pwd')->getOutput()));
+    }
+
+    /**
+     * Tests if ConnectionAdapterInterface::changeWorkingDirectory returns false when trying to change to a non-existing working directory.
+     *
+     * @depends testChangeWorkingDirectoryReturnsTrue
+     */
+    public function testChangeWorkingDirectoryWithNonExistingDirectoryReturnsFalse()
+    {
+        $this->connectionAdapter->connect();
+
+        $this->assertFalse($this->connectionAdapter->changeWorkingDirectory($this->workspaceUtility->getWorkspacePath().'/non-existing-directory'));
     }
 
     /**


### PR DESCRIPTION
`SSH2::exec` of the phpseclib library is stateless as it destroys the channel after executing the command. This way you can't execute a command that creates environment variables that you can re-use in following commands.

This PR changes `SSHConnectionAdapter::executeCommand` to write the commands to a persistent SSH channel.
