### PR TITLE
Improved output logging (verbosity levels)

### DIFF
--- a/src/Console/Formatter/OutputFormatter.php
+++ b/src/Console/Formatter/OutputFormatter.php
@@ -29,9 +29,9 @@ class OutputFormatter extends BaseOutputFormatter
         $this->setStyle(LogLevel::ALERT, new OutputFormatterStyle('white', 'red'));
         $this->setStyle(LogLevel::ERROR, new OutputFormatterStyle('white', 'red'));
         $this->setStyle(LogLevel::WARNING, new OutputFormatterStyle('white', 'red'));
-        $this->setStyle(LogLevel::NOTICE, new OutputFormatterStyle('white', 'blue'));
-        $this->setStyle(LogLevel::INFO, new OutputFormatterStyle());
-        $this->setStyle(LogLevel::DEBUG, new OutputFormatterStyle('black', 'yellow'));
+        $this->setStyle(LogLevel::NOTICE, new OutputFormatterStyle());
+        $this->setStyle(LogLevel::INFO, new OutputFormatterStyle('black', 'yellow'));
+        $this->setStyle(LogLevel::DEBUG, new OutputFormatterStyle());
         $this->setStyle('event-name', new OutputFormatterStyle('yellow'));
         $this->setStyle('event-task-name', new OutputFormatterStyle('yellow'));
         $this->setStyle('event-task-action-in_progress', new OutputFormatterStyle());

--- a/src/Console/Logger/ConsoleLogger.php
+++ b/src/Console/Logger/ConsoleLogger.php
@@ -83,8 +83,8 @@ class ConsoleLogger extends AbstractLogger
         LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::DEBUG => OutputInterface::VERBOSITY_VERBOSE,
+        LogLevel::INFO => OutputInterface::VERBOSITY_VERBOSE,
+        LogLevel::DEBUG => OutputInterface::VERBOSITY_VERY_VERBOSE,
     );
 
     /**

--- a/src/Task/ComposerInstallTask.php
+++ b/src/Task/ComposerInstallTask.php
@@ -76,6 +76,8 @@ class ComposerInstallTask extends AbstractConnectedTask
                 } else {
                     $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed installing the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_FAILED)));
                 }
+
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
             } else {
                 $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Updating the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
@@ -86,6 +88,8 @@ class ComposerInstallTask extends AbstractConnectedTask
                 } else {
                     $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed updating the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_FAILED)));
                 }
+
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
             }
 
             return;
@@ -125,5 +129,7 @@ class ComposerInstallTask extends AbstractConnectedTask
         if ($connection->isFile($authenticationFile)) {
             $connection->delete($authenticationFile);
         }
+
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
     }
 }

--- a/src/Task/ComposerInstallTask.php
+++ b/src/Task/ComposerInstallTask.php
@@ -67,22 +67,22 @@ class ComposerInstallTask extends AbstractConnectedTask
         $workspace = $event->getWorkspace();
         if ($workspace instanceof Workspace) {
             if ($connection->isFile($host->getPath().'/composer.phar') === false) {
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Installing the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Installing the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
                 $connection->changeWorkingDirectory($host->getPath());
                 $result = $connection->executeCommand('php -r "readfile(\'https://getcomposer.org/installer\');" | php');
-                if ($result->isSuccessful()) {
-                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Installed the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+                if ($result->isSuccessful() && $connection->isFile($host->getPath().'/composer.phar')) {
+                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Installed the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
                 } else {
                     $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed installing the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_FAILED)));
                 }
             } else {
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Updating the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Updating the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
                 $connection->changeWorkingDirectory($host->getPath());
                 $result = $connection->executeCommand('php composer.phar self-update');
                 if ($result->isSuccessful()) {
-                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Updated the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Updated the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
                 } else {
                     $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed updating the Composer binary.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_FAILED)));
                 }
@@ -107,7 +107,7 @@ class ComposerInstallTask extends AbstractConnectedTask
         $host = $release->getWorkspace()->getHost();
         $connection = $this->ensureConnection($host);
 
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Installing Composer dependencies.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Installing Composer dependencies.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
         $authenticationFile = $release->getPath().'/auth.json';
         if (empty($this->authentication) === false) {
@@ -117,7 +117,7 @@ class ComposerInstallTask extends AbstractConnectedTask
         $connection->changeWorkingDirectory($host->getPath());
         $result = $connection->executeCommand(sprintf('php composer.phar install --working-dir="%s" --no-dev --no-scripts --optimize-autoloader', $release->getPath()));
         if ($result->isSuccessful()) {
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Installed Composer dependencies.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Installed Composer dependencies.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
         } else {
             $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::CRITICAL, 'Failed installing Composer dependencies.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_FAILED, 'output.resetLine' => true)));
         }

--- a/src/Task/CreateWorkspaceTask.php
+++ b/src/Task/CreateWorkspaceTask.php
@@ -86,7 +86,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
      */
     public function onPrepareWorkspaceConstructWorkspaceInstance(WorkspaceEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Creating Workspace.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Creating Workspace.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
         $workspace = new Workspace($event->getHost());
         $workspace->setReleasesDirectory($this->releasesDirectory);
@@ -96,7 +96,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
 
         $event->setWorkspace($workspace);
 
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Created Workspace.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Created Workspace.', $eventName, $this, array('event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
     }
 
     /**
@@ -130,13 +130,13 @@ class CreateWorkspaceTask extends AbstractConnectedTask
         foreach ($directories as $directory) {
             $context = array('directory' => $directory, 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS);
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Creating directory "{directory}".', $eventName, $this, $context));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Creating directory "{directory}".', $eventName, $this, $context));
             if ($connection->isDirectory($directory) === false) {
                 if ($connection->createDirectory($directory)) {
                     $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                     $context['output.resetLine'] = true;
 
-                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Created directory "{directory}".', $eventName, $this, $context));
+                    $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Created directory "{directory}".', $eventName, $this, $context));
                 } else {
                     $context['event.task.action'] = TaskInterface::ACTION_FAILED;
                     $context['output.resetLine'] = true;
@@ -147,7 +147,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
                 $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                 $context['output.resetLine'] = true;
 
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Directory "{directory}" exists.', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Directory "{directory}" exists.', $eventName, $this, $context));
             }
         }
     }

--- a/src/Task/DeployReleaseTask.php
+++ b/src/Task/DeployReleaseTask.php
@@ -68,7 +68,7 @@ class DeployReleaseTask extends AbstractConnectedTask
                 $workspace->addRelease($release);
 
                 $context = array('currentReleaseVersion' => $currentRelease->getVersion());
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Detected release version "{currentReleaseVersion}" currently deployed.', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Detected release version "{currentReleaseVersion}" currently deployed.', $eventName, $this, $context));
 
                 $event->setCurrentRelease($currentRelease);
             }
@@ -91,7 +91,7 @@ class DeployReleaseTask extends AbstractConnectedTask
         $releasePath = $host->getPath().'/'.$host->getStage();
 
         $context = array('linkTarget' => $releasePath, 'releaseVersion' => $release->getVersion(), 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS);
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Linking "{linkTarget}" to release "{releaseVersion}".', $eventName, $this, $context));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Linking "{linkTarget}" to release "{releaseVersion}".', $eventName, $this, $context));
 
         if ($connection->isLink($releasePath) === false || $this->getRealPath($connection, $releasePath) !== $release->getPath()) {
             if ($connection->isLink($releasePath)) {
@@ -102,12 +102,12 @@ class DeployReleaseTask extends AbstractConnectedTask
                 $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                 $context['output.resetLine'] = true;
 
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Linked "{linkTarget}" to release "{releaseVersion}".', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Linked "{linkTarget}" to release "{releaseVersion}".', $eventName, $this, $context));
             } else {
                 $context['event.task.action'] = TaskInterface::ACTION_FAILED;
                 $context['output.resetLine'] = true;
 
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Linking "{linkTarget}" to release "{releaseVersion}" failed.', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Linking "{linkTarget}" to release "{releaseVersion}" failed.', $eventName, $this, $context));
 
                 throw new RuntimeException(sprintf('Linking "%s" to release "%s" failed.', $context['linkTarget'], $context['releaseVersion']));
             }
@@ -115,7 +115,7 @@ class DeployReleaseTask extends AbstractConnectedTask
             $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
             $context['output.resetLine'] = true;
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Link "{linkTarget}" to release "{releaseVersion}" already exists.', $eventName, $this, $context));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Link "{linkTarget}" to release "{releaseVersion}" already exists.', $eventName, $this, $context));
         }
     }
 

--- a/src/Task/ExecuteCommandTask.php
+++ b/src/Task/ExecuteCommandTask.php
@@ -80,14 +80,14 @@ class ExecuteCommandTask extends AbstractConnectedTask
 
             $currentWorkingDirectory = $connection->getWorkingDirectory();
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS)));
 
             $connection->changeWorkingDirectory($release->getPath());
             $result = $connection->executeCommand($this->command, $this->arguments);
             if ($result->isSuccessful()) {
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Executed command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Executed command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
             } else {
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_FAILED)));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_FAILED, 'output.resetLine' => true)));
             }
 
             $connection->changeWorkingDirectory($currentWorkingDirectory);

--- a/src/Task/ExecuteCommandTask.php
+++ b/src/Task/ExecuteCommandTask.php
@@ -90,6 +90,8 @@ class ExecuteCommandTask extends AbstractConnectedTask
                 $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_FAILED, 'output.resetLine' => true)));
             }
 
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
+
             $connection->changeWorkingDirectory($currentWorkingDirectory);
         }
     }

--- a/src/Task/MaintenanceModeTask.php
+++ b/src/Task/MaintenanceModeTask.php
@@ -80,13 +80,13 @@ class MaintenanceModeTask extends AbstractConnectedTask
         $directory = $host->getPath().'/maintenance/';
         $context = array('directory' => $directory, 'event.task.action' => TaskInterface::ACTION_IN_PROGRESS);
 
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Creating directory "{directory}".', $eventName, $this, $context));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Creating directory "{directory}".', $eventName, $this, $context));
         if ($connection->isDirectory($directory) === false) {
             if ($connection->createDirectory($directory)) {
                 $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
                 $context['output.resetLine'] = true;
 
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Created directory "{directory}".', $eventName, $this, $context));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Created directory "{directory}".', $eventName, $this, $context));
             } else {
                 $context['event.task.action'] = TaskInterface::ACTION_FAILED;
                 $context['output.resetLine'] = true;
@@ -97,7 +97,7 @@ class MaintenanceModeTask extends AbstractConnectedTask
             $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
             $context['output.resetLine'] = true;
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Directory "{directory}" exists.', $eventName, $this, $context));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Directory "{directory}" exists.', $eventName, $this, $context));
         }
 
         if ($connection->isDirectory($directory)) {
@@ -109,7 +109,7 @@ class MaintenanceModeTask extends AbstractConnectedTask
 
                     $uploaded = $connection->putFile($localFile, $host->getPath().'maintenance/'.$file);
                     if ($uploaded === true) {
-                        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Uploaded file "{file}".', $eventName, $this, $context));
+                        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Uploaded file "{file}".', $eventName, $this, $context));
                     }
                 }
             }
@@ -128,7 +128,7 @@ class MaintenanceModeTask extends AbstractConnectedTask
     public function onPrepareDeployReleaseLinkMaintenancePageToStage(PrepareDeployReleaseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
         if (VersionCategoryComparator::matchesStrategy($this->strategy, $event->getRelease(), $event->getCurrentRelease()) === false) {
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, 'Skipped linking maintenance page according to strategy.', $eventName, $this));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Skipped linking maintenance page according to strategy.', $eventName, $this));
 
             return;
         }

--- a/src/Task/RepositoryCheckoutTask.php
+++ b/src/Task/RepositoryCheckoutTask.php
@@ -80,14 +80,14 @@ class RepositoryCheckoutTask extends AbstractConnectedTask
         $connection = $this->ensureConnection($event->getRelease()->getWorkspace()->getHost());
         $processExecutor = new ConnectionAdapterProcessExecutor($connection);
 
-        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Creating checkout of repository "{repositoryUrl}" for version "{version}".', $eventName, $this, $context));
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Creating checkout of repository "{repositoryUrl}" for version "{version}".', $eventName, $this, $context));
 
         $repository = new Repository($this->repositoryUrl, $event->getRelease()->getPath(), $processExecutor);
         if ($repository->checkout($event->getRelease()->getVersion())) {
             $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;
             $context['output.resetLine'] = true;
 
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Created checkout of repository "{repositoryUrl}" for version "{version}".', $eventName, $this, $context));
+            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Created checkout of repository "{repositoryUrl}" for version "{version}".', $eventName, $this, $context));
         } else {
             throw new RuntimeException(sprintf('Checkout of repository "%s" for version "%s" failed.', $this->repositoryUrl, $event->getRelease()->getVersion()));
         }

--- a/tests/Console/Logger/ConsoleLoggerTest.php
+++ b/tests/Console/Logger/ConsoleLoggerTest.php
@@ -129,10 +129,10 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
         $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $outputMock->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
         $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
-        $outputMock->expects($this->once())->method('writeln')->with($this->equalTo('  <info>Message to Bob</info>'));
+        $outputMock->expects($this->once())->method('writeln')->with($this->equalTo('  <notice>Message to Bob</notice>'));
 
         $logger = new ConsoleLogger($outputMock);
-        $logger->log(LogLevel::INFO, 'Message to {user}', array('user' => 'Bob'));
+        $logger->log(LogLevel::NOTICE, 'Message to {user}', array('user' => 'Bob'));
     }
 
     /**
@@ -147,10 +147,10 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
         $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
         $outputMock->expects($this->once())
                 ->method('writeln')
-                ->with($this->equalTo('[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>]  <info>message</info>'));
+                ->with($this->equalTo('[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>]  <notice>message</notice>'));
 
         $logger = new ConsoleLogger($outputMock);
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
     }
 
     /**
@@ -166,13 +166,13 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
         $outputMock->expects($this->exactly(2))
                 ->method('writeln')
                 ->withConsecutive(
-                    array($this->equalTo('[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>]  <info>message</info>')),
-                    array($this->equalTo('                                                                 <info>message</info>'))
+                    array($this->equalTo('[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>]  <notice>message</notice>')),
+                    array($this->equalTo('                                                                 <notice>message</notice>'))
                 );
 
         $logger = new ConsoleLogger($outputMock);
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
     }
 
     /**
@@ -195,7 +195,7 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo($expectedLogMessage));
 
         $logger = new ConsoleLogger($outputMock);
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask', 'event.task.action' => $actionStatus));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask', 'event.task.action' => $actionStatus));
     }
 
     /**
@@ -215,8 +215,8 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
         $outputMock->expects($this->exactly(2))
                 ->method('writeln')
                 ->withConsecutive(
-                    array($this->equalTo("[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] \e[1D <info>message</info>")),
-                    array($this->equalTo(" \e[1D <info>message</info>"))
+                    array($this->equalTo("[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] \e[1D <notice>message</notice>")),
+                    array($this->equalTo(" \e[1D <notice>message</notice>"))
                 );
 
         $logger = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLogger')
@@ -225,8 +225,8 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
                 ->getMock();
         $logger->expects($this->exactly(2))->method('getTerminalWidth')->willReturn(150);
 
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
-        $logger->log(LogLevel::INFO, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask', 'output.resetLine' => true));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
+        $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask', 'output.resetLine' => true));
     }
 
     /**
@@ -251,8 +251,25 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
             array(LogLevel::ERROR, OutputInterface::VERBOSITY_NORMAL, true),
             array(LogLevel::WARNING, OutputInterface::VERBOSITY_NORMAL, true),
             array(LogLevel::NOTICE, OutputInterface::VERBOSITY_NORMAL, true),
-            array(LogLevel::INFO, OutputInterface::VERBOSITY_NORMAL, true),
+            array(LogLevel::INFO, OutputInterface::VERBOSITY_NORMAL, false),
             array(LogLevel::DEBUG, OutputInterface::VERBOSITY_NORMAL, false),
+            array(LogLevel::EMERGENCY, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::ALERT, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::CRITICAL, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::ERROR, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::WARNING, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::NOTICE, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::INFO, OutputInterface::VERBOSITY_VERBOSE, true),
+            array(LogLevel::DEBUG, OutputInterface::VERBOSITY_VERBOSE, false),
+            array(LogLevel::EMERGENCY, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::ALERT, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::CRITICAL, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::ERROR, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::WARNING, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::NOTICE, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::INFO, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::DEBUG, OutputInterface::VERBOSITY_VERY_VERBOSE, true),
+            array(LogLevel::EMERGENCY, OutputInterface::VERBOSITY_DEBUG, true),
             array(LogLevel::ALERT, OutputInterface::VERBOSITY_DEBUG, true),
             array(LogLevel::CRITICAL, OutputInterface::VERBOSITY_DEBUG, true),
             array(LogLevel::ERROR, OutputInterface::VERBOSITY_DEBUG, true),
@@ -286,9 +303,9 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
     public function provideTestLogTaskActionStatus()
     {
         return array(
-            array(TaskInterface::ACTION_IN_PROGRESS, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-in_progress>...</event-task-action-in_progress>] <info>message</info>'),
-            array(TaskInterface::ACTION_COMPLETED, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-completed> ✓ </event-task-action-completed>] <info>message</info>'),
-            array(TaskInterface::ACTION_FAILED, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-failed>!!!</event-task-action-failed>] <info>message</info>'),
+            array(TaskInterface::ACTION_IN_PROGRESS, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-in_progress>...</event-task-action-in_progress>] <notice>message</notice>'),
+            array(TaskInterface::ACTION_COMPLETED, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-completed> ✓ </event-task-action-completed>] <notice>message</notice>'),
+            array(TaskInterface::ACTION_FAILED, '[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>] [<event-task-action-failed>!!!</event-task-action-failed>] <notice>message</notice>'),
         );
     }
 }

--- a/tests/Task/ComposerInstallTaskTest.php
+++ b/tests/Task/ComposerInstallTaskTest.php
@@ -44,10 +44,13 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnPrepareWorkspaceInstallComposerInstallsComposer()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isFile')->willReturn(false);
+        $connectionAdapterMock->expects($this->exactly(2))
+                ->method('isFile')
+                ->with($this->equalTo('{workspace}/composer.phar'))
+                ->willReturnOnConsecutiveCalls(false, true);
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with('php -r "readfile(\'https://getcomposer.org/installer\');" | php')
@@ -58,6 +61,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->getMock();
         $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
         $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->exactly(3))->method('getPath')->willReturn('{workspace}');
 
         $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
                 ->disableOriginalConstructor()
@@ -76,7 +80,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnPrepareWorkspaceInstallComposerFailsInstallingComposer()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())->method('isFile')->willReturn(false);
@@ -108,7 +112,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnPrepareWorkspaceInstallComposerUpdatesComposer()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())->method('isFile')->willReturn(true);
@@ -140,7 +144,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnPrepareWorkspaceInstallComposerFailsUpdatingComposer()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())->method('isFile')->willReturn(true);
@@ -196,7 +200,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnInstallReleaseExecuteComposerInstall()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())
@@ -233,7 +237,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnInstallReleaseExecuteComposerInstallWithAuthentication()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())
@@ -282,7 +286,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnInstallReleaseExecuteComposerInstallFails()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())

--- a/tests/Task/ExecuteCommandTaskTest.php
+++ b/tests/Task/ExecuteCommandTaskTest.php
@@ -45,7 +45,7 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
     public function testOnEvent()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->atLeast(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');
@@ -86,7 +86,7 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
     public function testOnEventFailure()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->atLeast(2))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');


### PR DESCRIPTION
Shifted the following LogLevels in tasks:
- `LogLevel::INFO` to `LogLevel::NOTICE`
- `LogLevel::DEBUG` to `LogLevel::INFO`

Implemented `LogLevel::DEBUG` for command output in the following tasks:
- `ComposerInstallTask`
- `ExecuteCommandTask`
