### PR TITLE
Improved existing logging / reporting and added failure reporting

### DIFF
--- a/src/Accompli.php
+++ b/src/Accompli.php
@@ -82,6 +82,8 @@ class Accompli
         $this->initializeStreamWrapper();
         $this->initializeContainer();
         $this->initializeEventListeners();
+
+        $this->dispatch(AccompliEvents::INITIALIZE);
     }
 
     /**
@@ -163,7 +165,11 @@ class Accompli
     {
         $deploymentStrategy = $this->getContainer()->get('deployment_strategy');
 
-        return $deploymentStrategy->install($version, $stage);
+        $result = $deploymentStrategy->install($version, $stage);
+
+        $this->dispatch(AccompliEvents::INSTALL_COMMAND_COMPLETE);
+
+        return $result;
     }
 
     /**
@@ -178,7 +184,11 @@ class Accompli
     {
         $deploymentStrategy = $this->getContainer()->get('deployment_strategy');
 
-        return $deploymentStrategy->deploy($version, $stage);
+        $result = $deploymentStrategy->deploy($version, $stage);
+
+        $this->dispatch(AccompliEvents::DEPLOY_COMMAND_COMPLETE);
+
+        return $result;
     }
 
     /**
@@ -196,5 +206,15 @@ class Accompli
         $loader->load('services.yml');
 
         return $container;
+    }
+
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string $eventName
+     */
+    private function dispatch($eventName)
+    {
+        $this->getContainer()->get('event_dispatcher')->dispatch($eventName);
     }
 }

--- a/src/AccompliEvents.php
+++ b/src/AccompliEvents.php
@@ -20,6 +20,16 @@ final class AccompliEvents
     const CREATE_CONNECTION = 'accompli.create_connection';
 
     /**
+     * The DEPLOY_COMMAND_COMPLETE event is dispatched at the end of Accompli::deploy.
+     *
+     * The event listener recieves an
+     * Symfony\Component\EventDispatcher\Event instance.
+     *
+     * @var string
+     */
+    const DEPLOY_COMMAND_COMPLETE = 'accompli.deploy_command_complete';
+
+    /**
      * The DEPLOY_RELEASE event is dispatched when a Release is ready for deployment.
      *
      * The event listener receives an
@@ -68,6 +78,26 @@ final class AccompliEvents
      * @var string
      */
     const GET_WORKSPACE = 'accompli.get_workspace';
+
+    /**
+     * The INITIALIZE event is dispatched when the service container, configuration and event dispatcher are fully configured.
+     *
+     * The event listener recieves an
+     * Symfony\Component\EventDispatcher\Event instance.
+     *
+     * @var string
+     */
+    const INITIALIZE = 'accompli.initialize';
+
+    /**
+     * The INSTALL_COMMAND_COMPLETE event is dispatched at the end of Accompli::install.
+     *
+     * The event listener recieves an
+     * Symfony\Component\EventDispatcher\Event instance.
+     *
+     * @var string
+     */
+    const INSTALL_COMMAND_COMPLETE = 'accompli.install_command_complete';
 
     /**
      * The INSTALL_RELEASE event is dispatched when a Release requires installation.
@@ -178,11 +208,14 @@ final class AccompliEvents
     {
         return array(
             self::CREATE_CONNECTION,
+            self::DEPLOY_COMMAND_COMPLETE,
             self::DEPLOY_RELEASE,
             self::DEPLOY_RELEASE_COMPLETE,
             self::DEPLOY_RELEASE_FAILED,
             self::GATHER_FACTS,
             self::GET_WORKSPACE,
+            self::INITIALIZE,
+            self::INSTALL_COMMAND_COMPLETE,
             self::INSTALL_RELEASE,
             self::INSTALL_RELEASE_COMPLETE,
             self::INSTALL_RELEASE_FAILED,

--- a/src/Console/Formatter/OutputFormatter.php
+++ b/src/Console/Formatter/OutputFormatter.php
@@ -24,6 +24,7 @@ class OutputFormatter extends BaseOutputFormatter
     {
         parent::__construct($decorated, $styles);
 
+        $this->setStyle('title', new OutputFormatterStyle());
         $this->setStyle(LogLevel::EMERGENCY, new OutputFormatterStyle('white', 'red'));
         $this->setStyle(LogLevel::CRITICAL, new OutputFormatterStyle('white', 'red'));
         $this->setStyle(LogLevel::ALERT, new OutputFormatterStyle('white', 'red'));

--- a/src/Console/Helper/Title.php
+++ b/src/Console/Helper/Title.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Accompli\Console\Helper;
+
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Title.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class Title
+{
+    /**
+     * The OutputInterface instance.
+     *
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * The title message to be rendered.
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * Constructs a new Title instance.
+     *
+     * @param OutputInterface $output
+     * @param string          $message
+     */
+    public function __construct(OutputInterface $output, $message)
+    {
+        $this->output = $output;
+        $this->message = $message;
+    }
+
+    /**
+     * Renders the title to output.
+     */
+    public function render()
+    {
+        $this->output->writeln(array(
+            '',
+            sprintf('<title>%s</>', $this->message),
+            sprintf('<title>%s</>', str_repeat('=', Helper::strlenWithoutDecoration($this->output->getFormatter(), $this->message))),
+            '',
+        ));
+    }
+}

--- a/src/Console/Helper/TitleBlock.php
+++ b/src/Console/Helper/TitleBlock.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Accompli\Console\Helper;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * TitleBlock.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TitleBlock extends Title
+{
+    /**
+     * @var string
+     */
+    const STYLE_SUCCESS = 'success';
+
+    /**
+     * @var string
+     */
+    const STYLE_ERRORED_SUCCESS = 'errored-success';
+
+    /**
+     * @var string
+     */
+    const STYLE_FAILURE = 'failure';
+
+    /**
+     * The styles for title blocks.
+     *
+     * @var array
+     */
+    private $blockStyles = array(
+        self::STYLE_SUCCESS => array(
+            'prefix' => '[OK]',
+            'style' => 'fg=black;bg=green',
+        ),
+        self::STYLE_ERRORED_SUCCESS => array(
+            'prefix' => '[OK, but with errors]',
+            'style' => 'fg=black;bg=yellow',
+        ),
+        self::STYLE_FAILURE => array(
+            'prefix' => '[FAILURE]',
+            'style' => 'fg=white;bg=red',
+        ),
+    );
+
+    /**
+     * The specified render style for this title block.
+     *
+     * @var string
+     */
+    private $style;
+
+    /**
+     * Constructs a new TitleBlock instance.
+     *
+     * @param OutputInterface $output
+     * @param string          $message
+     * @param string          $style
+     */
+    public function __construct(OutputInterface $output, $message, $style)
+    {
+        parent::__construct($output, $message);
+
+        $this->style = $style;
+    }
+
+    /**
+     * Renders the title block to output.
+     */
+    public function render()
+    {
+        $this->output->writeln('');
+
+        $lineLength = $this->getTerminalWidth();
+
+        $lines = explode(PHP_EOL, wordwrap($this->message, $lineLength - (strlen($this->blockStyles[$this->style]['prefix']) + 3), PHP_EOL, true));
+        array_unshift($lines, ' ');
+        array_push($lines, ' ');
+
+        foreach ($lines as $i => $line) {
+            $prefix = str_repeat(' ', strlen($this->blockStyles[$this->style]['prefix']));
+            if ($i === 1) {
+                $prefix = $this->blockStyles[$this->style]['prefix'];
+            }
+
+            $line = sprintf(' %s %s', $prefix, $line);
+            $this->output->writeln(sprintf('<%s>%s%s</>', $this->blockStyles[$this->style]['style'], $line, str_repeat(' ', $lineLength - Helper::strlenWithoutDecoration($this->output->getFormatter(), $line))));
+        }
+
+        $this->output->writeln('');
+    }
+
+    /**
+     * Returns the terminal width.
+     *
+     * @return int
+     */
+    private function getTerminalWidth()
+    {
+        $application = new Application();
+        $terminalDimensions = $application->getTerminalDimensions();
+
+        $width = 120;
+        if (isset($terminalDimensions[0])) {
+            $width = $terminalDimensions[0];
+        }
+
+        return $width;
+    }
+}

--- a/src/Console/Logger/ConsoleLogger.php
+++ b/src/Console/Logger/ConsoleLogger.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Niels Nijens <nijens.niels@gmail.com>
  */
-class ConsoleLogger extends AbstractLogger
+class ConsoleLogger extends AbstractLogger implements ConsoleLoggerInterface
 {
     /**
      * ANSI code to move the cursor up by the specified number (%d) of lines without changing columns.
@@ -132,6 +132,27 @@ class ConsoleLogger extends AbstractLogger
     /**
      * {@inheritdoc}
      */
+    public function getVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOutput($level = LogLevel::NOTICE)
+    {
+        $output = $this->output;
+        if ($this->output instanceof ConsoleOutputInterface && in_array($level, array(LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR))) {
+            $output = $this->output->getErrorOutput();
+        }
+
+        return $output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function log($level, $message, array $context = array())
     {
         if (isset($this->logLevelToVerbosityLevelMap[$level]) === false) {
@@ -182,23 +203,6 @@ class ConsoleLogger extends AbstractLogger
         }
 
         return $width;
-    }
-
-    /**
-     * Returns the instance handling the output to the console.
-     *
-     * @param string $level
-     *
-     * @return OutputInterface
-     */
-    private function getOutput($level)
-    {
-        $output = $this->output;
-        if ($this->output instanceof ConsoleOutputInterface && in_array($level, array(LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR))) {
-            $output = $this->output->getErrorOutput();
-        }
-
-        return $output;
     }
 
     /**

--- a/src/Console/Logger/ConsoleLoggerInterface.php
+++ b/src/Console/Logger/ConsoleLoggerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Accompli\Console\Logger;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ConsoleLoggerInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface ConsoleLoggerInterface extends LoggerInterface
+{
+    /**
+     * Returns the verbosity of the OutputInterface instance.
+     *
+     * @return int
+     */
+    public function getVerbosity();
+
+    /**
+     * Returns the instance handling the output to the console.
+     *
+     * @param string $level
+     *
+     * @return OutputInterface
+     */
+    public function getOutput($level = LogLevel::NOTICE);
+}

--- a/src/DataCollector/DataCollectorInterface.php
+++ b/src/DataCollector/DataCollectorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Accompli\DataCollector;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * DataCollectorInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface DataCollectorInterface
+{
+    /**
+     * Collect data from the event.
+     *
+     * @param Event  $event
+     * @param string $eventName
+     */
+    public function collect(Event $event, $eventName);
+
+    /**
+     * Returns the collected data (filtered by verbosity).
+     *
+     * @param int $verbosity
+     *
+     * @return array
+     */
+    public function getData($verbosity = OutputInterface::VERBOSITY_NORMAL);
+}

--- a/src/DataCollector/EventDataCollector.php
+++ b/src/DataCollector/EventDataCollector.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Accompli\DataCollector;
+
+use Accompli\EventDispatcher\Event\FailedEvent;
+use Accompli\EventDispatcher\Event\LogEvent;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * EventDataCollector.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class EventDataCollector implements DataCollectorInterface
+{
+    /**
+     * The amount of LogEvent instances counted of a specific LogLevel.
+     *
+     * @var array
+     */
+    private $logLevelCount = array(
+        LogLevel::EMERGENCY => 0,
+        LogLevel::ALERT => 0,
+        LogLevel::CRITICAL => 0,
+        LogLevel::ERROR => 0,
+        LogLevel::WARNING => 0,
+        LogLevel::NOTICE => 0,
+        LogLevel::INFO => 0,
+        LogLevel::DEBUG => 0,
+    );
+
+    /**
+     * The amount of FailedEvent instances counted.
+     *
+     * @var int
+     */
+    private $failedEventCount = 0;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Event $event, $eventName)
+    {
+        if ($event instanceof LogEvent) {
+            ++$this->logLevelCount[$event->getLevel()];
+        } elseif ($event instanceof FailedEvent) {
+            ++$this->failedEventCount;
+        }
+    }
+
+    /**
+     * Returns true if LogEvent instances are counted for a certain LogLevel.
+     *
+     * @param string $logLevel
+     *
+     * @return bool
+     */
+    public function hasCountedLogLevel($logLevel)
+    {
+        if (isset($this->logLevelCount[$logLevel])) {
+            return $this->logLevelCount[$logLevel] > 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if FailedEvent instances are counted.
+     *
+     * @return bool
+     */
+    public function hasCountedFailedEvents()
+    {
+        return $this->failedEventCount > 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        return array();
+    }
+}

--- a/src/DataCollector/ProfilerDataCollector.php
+++ b/src/DataCollector/ProfilerDataCollector.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Accompli\DataCollector;
+
+use Accompli\AccompliEvents;
+use DateTime;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * ProfilerDataCollector.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ProfilerDataCollector implements DataCollectorInterface
+{
+    /**
+     * The start DateTime instance.
+     *
+     * @var DateTime
+     */
+    private $start;
+
+    /**
+     * The end DateTime instance.
+     *
+     * @var DateTime
+     */
+    private $end;
+
+    /**
+     * The peak memory usage in bytes.
+     *
+     * @var int
+     */
+    private $peakMemoryUsage = 0;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Event $event, $eventName)
+    {
+        if ($eventName === AccompliEvents::INITIALIZE) {
+            $this->start = new DateTime('now');
+        } elseif (in_array($eventName, array(AccompliEvents::INSTALL_COMMAND_COMPLETE, AccompliEvents::DEPLOY_COMMAND_COMPLETE))) {
+            $this->end = new DateTime('now');
+            $this->peakMemoryUsage = memory_get_peak_usage(true);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        $data = array();
+
+        if ($verbosity >= OutputInterface::VERBOSITY_VERBOSE) {
+            $executionTime = 'Unknown';
+            if ($this->start instanceof DateTime !== false && $this->end instanceof DateTime !== false) {
+                $durationInterval = $this->start->diff($this->end);
+                $durationInterval->h = $durationInterval->d * 24;
+                $durationInterval->i = $durationInterval->h * 60;
+                if ($durationInterval->i === 0 && $durationInterval->s === 0) {
+                    ++$durationInterval->s;
+                }
+
+                $executionTime = $durationInterval->format('%i minute(s) and %s second(s)');
+            }
+
+            $data['Execution time'] = $executionTime;
+        }
+
+        if ($verbosity >= OutputInterface::VERBOSITY_DEBUG) {
+            $data['Peak memory usage'] = round($this->peakMemoryUsage / 1024 / 1024, 2).' MB';
+        }
+
+        return $data;
+    }
+}

--- a/src/DependencyInjection/LoggerAwareInterface.php
+++ b/src/DependencyInjection/LoggerAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Accompli\DependencyInjection;
+
+use Accompli\Console\Logger\ConsoleLoggerInterface;
+
+/**
+ * LoggerAwareInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface LoggerAwareInterface
+{
+    /**
+     * Sets the console logger.
+     *
+     * @param ConsoleLoggerInterface $logger
+     */
+    public function setLogger(ConsoleLoggerInterface $logger);
+}

--- a/src/Deployment/Strategy/AbstractDeploymentStrategy.php
+++ b/src/Deployment/Strategy/AbstractDeploymentStrategy.php
@@ -102,7 +102,7 @@ abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface
 
             $successfulDeploy = false;
 
-            $failedEvent = new FailedEvent($this->eventDispatcher->getLastDispatchedEvent(), $exception);
+            $failedEvent = new FailedEvent($this->eventDispatcher->getLastDispatchedEventName(), $this->eventDispatcher->getLastDispatchedEvent(), $exception);
             $this->eventDispatcher->dispatch($deployFailedEventName, $failedEvent);
         }
 

--- a/src/Deployment/Strategy/AbstractDeploymentStrategy.php
+++ b/src/Deployment/Strategy/AbstractDeploymentStrategy.php
@@ -4,6 +4,7 @@ namespace Accompli\Deployment\Strategy;
 
 use Accompli\AccompliEvents;
 use Accompli\Configuration\ConfigurationInterface;
+use Accompli\Console\Helper\Title;
 use Accompli\Console\Logger\ConsoleLoggerInterface;
 use Accompli\DependencyInjection\ConfigurationAwareInterface;
 use Accompli\DependencyInjection\EventDispatcherAwareInterface;
@@ -85,6 +86,9 @@ abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface
             $deployEventName = AccompliEvents::DEPLOY_RELEASE;
             $deployCompleteEventName = AccompliEvents::DEPLOY_RELEASE_COMPLETE;
             $deployFailedEventName = AccompliEvents::DEPLOY_RELEASE_FAILED;
+
+            $title = new Title($this->logger->getOutput(), sprintf('Deploying release "%s" to "%s":', $version, $host->getHostname()));
+            $title->render();
 
             try {
                 $this->eventDispatcher->dispatch(AccompliEvents::CREATE_CONNECTION, new HostEvent($host));

--- a/src/Deployment/Strategy/AbstractDeploymentStrategy.php
+++ b/src/Deployment/Strategy/AbstractDeploymentStrategy.php
@@ -4,8 +4,10 @@ namespace Accompli\Deployment\Strategy;
 
 use Accompli\AccompliEvents;
 use Accompli\Configuration\ConfigurationInterface;
+use Accompli\Console\Logger\ConsoleLoggerInterface;
 use Accompli\DependencyInjection\ConfigurationAwareInterface;
 use Accompli\DependencyInjection\EventDispatcherAwareInterface;
+use Accompli\DependencyInjection\LoggerAwareInterface;
 use Accompli\Deployment\Release;
 use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\DeployReleaseEvent;
@@ -22,7 +24,7 @@ use Exception;
  *
  * @author Niels Nijens <niels@connectholland.nl>
  */
-abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface, ConfigurationAwareInterface, EventDispatcherAwareInterface
+abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface, ConfigurationAwareInterface, EventDispatcherAwareInterface, LoggerAwareInterface
 {
     /**
      * The configuration instance.
@@ -39,6 +41,13 @@ abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface
     protected $eventDispatcher;
 
     /**
+     * The console logger instance.
+     *
+     * @var ConsoleLoggerInterface
+     */
+    protected $logger;
+
+    /**
      * {@inheritdoc}
      */
     public function setConfiguration(ConfigurationInterface $configuration)
@@ -52,6 +61,14 @@ abstract class AbstractDeploymentStrategy implements DeploymentStrategyInterface
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
     {
         $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(ConsoleLoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**

--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -60,7 +60,7 @@ class RemoteInstallStrategy extends AbstractDeploymentStrategy
 
             $successfulInstall = false;
 
-            $failedEvent = new FailedEvent($this->eventDispatcher->getLastDispatchedEvent(), $exception);
+            $failedEvent = new FailedEvent($this->eventDispatcher->getLastDispatchedEventName(), $this->eventDispatcher->getLastDispatchedEvent(), $exception);
             $this->eventDispatcher->dispatch(AccompliEvents::INSTALL_RELEASE_FAILED, $failedEvent);
         }
 

--- a/src/Deployment/Strategy/RemoteInstallStrategy.php
+++ b/src/Deployment/Strategy/RemoteInstallStrategy.php
@@ -3,6 +3,7 @@
 namespace Accompli\Deployment\Strategy;
 
 use Accompli\AccompliEvents;
+use Accompli\Console\Helper\Title;
 use Accompli\Deployment\Release;
 use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\FailedEvent;
@@ -33,6 +34,9 @@ class RemoteInstallStrategy extends AbstractDeploymentStrategy
 
         foreach ($hosts as $host) {
             $exception = null;
+
+            $title = new Title($this->logger->getOutput(), sprintf('Installing release "%s" to "%s":', $version, $host->getHostname()));
+            $title->render();
 
             try {
                 $this->eventDispatcher->dispatch(AccompliEvents::CREATE_CONNECTION, new HostEvent($host));

--- a/src/EventDispatcher/Event/FailedEvent.php
+++ b/src/EventDispatcher/Event/FailedEvent.php
@@ -13,6 +13,13 @@ use Symfony\Component\EventDispatcher\Event;
 class FailedEvent extends Event
 {
     /**
+     * The last event name dispatched before the failure occured.
+     *
+     * @var string
+     */
+    private $eventName;
+
+    /**
      * The last event dispatched before the failure occurred.
      *
      * @var Event
@@ -29,13 +36,25 @@ class FailedEvent extends Event
     /**
      * Constructs a new FailedEvent.
      *
+     * @param string    $eventName
      * @param Event     $event
      * @param Exception $exception
      */
-    public function __construct(Event $event, Exception $exception = null)
+    public function __construct($eventName, Event $event, Exception $exception = null)
     {
+        $this->eventName = $eventName;
         $this->event = $event;
         $this->exception = $exception;
+    }
+
+    /**
+     * Returns the last event name that was dispatched.
+     *
+     * @return string
+     */
+    public function getLastEventName()
+    {
+        return $this->eventName;
     }
 
     /**

--- a/src/EventDispatcher/Event/LogEvent.php
+++ b/src/EventDispatcher/Event/LogEvent.php
@@ -50,7 +50,7 @@ class LogEvent extends Event
     private $context;
 
     /**
-     * Constructs a new LogEvent.
+     * Constructs a new LogEvent instance.
      *
      * @param string                        $level
      * @param string                        $message
@@ -65,8 +65,8 @@ class LogEvent extends Event
         }
 
         $this->level = $level;
-        $this->eventNameContext = $eventNameContext;
         $this->message = $message;
+        $this->eventNameContext = $eventNameContext;
         $this->eventSubscriberContext = $eventSubscriberContext;
         $this->context = $context;
     }

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\EventDispatcher;
 
+use Accompli\AccompliEvents;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher as BaseEventDispatcher;
 
@@ -12,6 +13,13 @@ use Symfony\Component\EventDispatcher\EventDispatcher as BaseEventDispatcher;
  */
 class EventDispatcher extends BaseEventDispatcher implements EventDispatcherInterface
 {
+    /**
+     * The name of the last dispatched event.
+     *
+     * @var string
+     */
+    private $lastDispatchedEventName;
+
     /**
      * The instance of the last dispatched event.
      *
@@ -28,9 +36,20 @@ class EventDispatcher extends BaseEventDispatcher implements EventDispatcherInte
             $event = new Event();
         }
 
-        $this->lastDispatchedEvent = $event;
+        if ($eventName !== AccompliEvents::LOG) {
+            $this->lastDispatchedEventName = $eventName;
+            $this->lastDispatchedEvent = $event;
+        }
 
         return parent::dispatch($eventName, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastDispatchedEventName()
+    {
+        return $this->lastDispatchedEventName;
     }
 
     /**

--- a/src/EventDispatcher/EventDispatcherInterface.php
+++ b/src/EventDispatcher/EventDispatcherInterface.php
@@ -13,6 +13,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface as BaseEventDispa
 interface EventDispatcherInterface extends BaseEventDispatcherInterface
 {
     /**
+     * Returns the last dispatched event name.
+     *
+     * @return string
+     */
+    public function getLastDispatchedEventName();
+
+    /**
      * Returns the last dispatched Event instance.
      *
      * @return Event

--- a/src/EventDispatcher/Subscriber/DataCollectorSubscriber.php
+++ b/src/EventDispatcher/Subscriber/DataCollectorSubscriber.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Accompli\EventDispatcher\Subscriber;
+
+use Accompli\AccompliEvents;
+use Accompli\DataCollector\DataCollectorInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * DataCollectorSubscriber.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class DataCollectorSubscriber implements EventSubscriberInterface
+{
+    /**
+     * The array with DataCollectorInterface instances.
+     *
+     * @var DataCollectorInterface[]
+     */
+    private $dataCollectors;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        $subscribedEvents = array();
+        foreach (AccompliEvents::getEventNames() as $eventName) {
+            $subscribedEvents[$eventName] = array(
+                array('onEvent', 0),
+            );
+        }
+
+        return $subscribedEvents;
+    }
+
+    /**
+     * Constructs a new DataCollectorSubscriber instance.
+     *
+     * @param DataCollectorInterface[] $dataCollectors
+     */
+    public function __construct(array $dataCollectors = array())
+    {
+        $this->dataCollectors = $dataCollectors;
+    }
+
+    /**
+     * Adds a data collector instance.
+     *
+     * @param DataCollectorInterface $dataCollector
+     */
+    public function addDataCollector(DataCollectorInterface $dataCollector)
+    {
+        $this->dataCollectors[] = $dataCollector;
+    }
+
+    /**
+     * Calls the collect method on all registered data collectors.
+     *
+     * @param Event  $event
+     * @param string $eventName
+     */
+    public function onEvent(Event $event, $eventName)
+    {
+        foreach ($this->dataCollectors as $dataCollector) {
+            $dataCollector->collect($event, $eventName);
+        }
+    }
+}

--- a/src/EventDispatcher/Subscriber/GenerateReportSubscriber.php
+++ b/src/EventDispatcher/Subscriber/GenerateReportSubscriber.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Accompli\EventDispatcher\Subscriber;
+
+use Accompli\AccompliEvents;
+use Accompli\Console\Logger\ConsoleLoggerInterface;
+use Accompli\DataCollector\DataCollectorInterface;
+use Accompli\DataCollector\EventDataCollector;
+use Accompli\Report\DeployReport;
+use Accompli\Report\InstallReport;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * GenerateReportSubscriber.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class GenerateReportSubscriber implements EventSubscriberInterface
+{
+    /**
+     * The logger instance.
+     *
+     * @var ConsoleLoggerInterface
+     */
+    private $logger;
+
+    /**
+     * The EventDataCollector instance.
+     *
+     * @var EventDataCollector
+     */
+    private $eventDataCollector;
+
+    /**
+     * The array with DataCollectorInterface instances.
+     *
+     * @var DataCollectorInterface[]
+     */
+    private $dataCollectors;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            AccompliEvents::INSTALL_COMMAND_COMPLETE => array(
+                array('onInstallCommandCompletedOutputReport', 0),
+            ),
+            AccompliEvents::DEPLOY_COMMAND_COMPLETE => array(
+                array('onDeployCommandCompletedOutputReport', 0),
+            ),
+        );
+    }
+
+    /**
+     * Constructs a new GenerateReportSubscriber instance.
+     *
+     * @param ConsoleLoggerInterface   $logger
+     * @param EventDataCollector       $eventDataCollector
+     * @param DataCollectorInterface[] $dataCollectors
+     */
+    public function __construct(ConsoleLoggerInterface $logger, EventDataCollector $eventDataCollector, array $dataCollectors)
+    {
+        $this->logger = $logger;
+        $this->eventDataCollector = $eventDataCollector;
+        $this->dataCollectors = $dataCollectors;
+    }
+
+    /**
+     * Generates an installation report.
+     */
+    public function onInstallCommandCompletedOutputReport()
+    {
+        $report = new InstallReport($this->eventDataCollector, $this->dataCollectors);
+        $report->generate($this->logger);
+    }
+
+    /**
+     * Generates a deployment report.
+     */
+    public function onDeployCommandCompletedOutputReport()
+    {
+        $report = new DeployReport($this->eventDataCollector, $this->dataCollectors);
+        $report->generate($this->logger);
+    }
+}

--- a/src/EventDispatcher/Subscriber/LogFailureSubscriber.php
+++ b/src/EventDispatcher/Subscriber/LogFailureSubscriber.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Accompli\EventDispatcher\Subscriber;
+
+use Accompli\AccompliEvents;
+use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\EventDispatcher\Event\FailedEvent;
+use Accompli\Exception\TaskCommandExecutionException;
+use Accompli\Exception\TaskRuntimeException;
+use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * LogFailureSubscriber.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class LogFailureSubscriber implements EventSubscriberInterface
+{
+    /**
+     * The logger instance.
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            AccompliEvents::INSTALL_RELEASE_FAILED => array(
+                array('onFailedEventLogToLogger', 0),
+            ),
+            AccompliEvents::DEPLOY_RELEASE_FAILED => array(
+                array('onFailedEventLogToLogger', 0),
+            ),
+            AccompliEvents::ROLLBACK_RELEASE_FAILED => array(
+                array('onFailedEventLogToLogger', 0),
+            ),
+        );
+    }
+
+    /**
+     * Constructs a new LogFailureSubscriber instance.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Logs the FailedEvent to the logger instance.
+     *
+     * @param FailedEvent $event
+     */
+    public function onFailedEventLogToLogger(FailedEvent $event)
+    {
+        $context = array(
+            'event.name' => $event->getLastEventName(),
+        );
+
+        $message = 'An unknown error occured.';
+        $exception = $event->getException();
+        if ($exception instanceof Exception) {
+            $message = $exception->getMessage();
+        }
+        if ($exception instanceof TaskRuntimeException && $exception->getTask() instanceof EventSubscriberInterface) {
+            $eventSubscriberClassName = get_class($exception->getTask());
+            if (strrpos($eventSubscriberClassName, '\\') !== false) {
+                $eventSubscriberClassName = substr($eventSubscriberClassName, strrpos($eventSubscriberClassName, '\\') + 1);
+            }
+            $context['event.task.name'] = $eventSubscriberClassName;
+        }
+
+        $this->logger->log(LogLevel::CRITICAL, $message, $context);
+        if ($exception instanceof TaskCommandExecutionException && $exception->getProcessExecutionResult() instanceof ProcessExecutionResult) {
+            $context['command.result'] = $exception->getProcessExecutionResult()->getOutput();
+            $context['separator'] = "\n=================\n";
+
+            $this->logger->log(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $context);
+        }
+    }
+}

--- a/src/EventDispatcher/Subscriber/LogSubscriber.php
+++ b/src/EventDispatcher/Subscriber/LogSubscriber.php
@@ -4,7 +4,6 @@ namespace Accompli\EventDispatcher\Subscriber;
 
 use Accompli\AccompliEvents;
 use Accompli\EventDispatcher\Event\LogEvent;
-use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -13,7 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Niels Nijens <nijens.niels@gmail.com>
  */
-class LogSubscriber implements EventSubscriberInterface, LoggerAwareInterface
+class LogSubscriber implements EventSubscriberInterface
 {
     /**
      * The logger instance.
@@ -35,11 +34,11 @@ class LogSubscriber implements EventSubscriberInterface, LoggerAwareInterface
     }
 
     /**
-     * Sets a logger instance.
+     * Constructs a new LogSubscriber instance.
      *
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }

--- a/src/Exception/TaskCommandExecutionException.php
+++ b/src/Exception/TaskCommandExecutionException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Accompli\Exception;
+
+use Accompli\Chrono\Process\ProcessExecutionResult;
+use Exception;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * TaskCommandExecutionException is thrown when an executed command returns an unsuccessful status.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TaskCommandExecutionException extends TaskRuntimeException
+{
+    /**
+     * The ProcessExecutionResult instance from the executed command.
+     *
+     * @var string
+     */
+    private $processExecutionResult;
+
+    /**
+     * Constructs a new TaskCommandExecutionException instance.
+     *
+     * @param string                   $message
+     * @param ProcessExecutionResult   $result
+     * @param EventSubscriberInterface $task
+     * @param int                      $code
+     * @param Exception                $previous
+     */
+    public function __construct($message = '', ProcessExecutionResult $result = null, EventSubscriberInterface $task = null, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $task, $code, $previous);
+
+        $this->processExecutionResult = $result;
+    }
+
+    /**
+     * Returns the ProcessExecutionResult instance.
+     *
+     * @return string
+     */
+    public function getProcessExecutionResult()
+    {
+        return $this->processExecutionResult;
+    }
+}

--- a/src/Exception/TaskRuntimeException.php
+++ b/src/Exception/TaskRuntimeException.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Accompli\Exception;
+
+use Exception;
+use RuntimeException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * TaskRuntimeException.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TaskRuntimeException extends RuntimeException // Change extend?
+{
+    /**
+     * The running task when the exception occurred.
+     *
+     * @var EventSubscriberInterface
+     */
+    private $task;
+
+    /**
+     * Constructs a new TaskRuntimeException instance.
+     *
+     * @param string                        $message
+     * @param EventSubscriberInterface|null $task
+     * @param int                           $code
+     * @param Exception|null                $previous
+     */
+    public function __construct($message = '', EventSubscriberInterface $task = null, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->task = $task;
+    }
+
+    /**
+     * Returns the task instance.
+     *
+     * @return EventSubscriberInterface
+     */
+    public function getTask()
+    {
+        return $this->task;
+    }
+}

--- a/src/Report/AbstractReport.php
+++ b/src/Report/AbstractReport.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Accompli\Report;
+
+use Accompli\Console\Helper\TitleBlock;
+use Accompli\Console\Logger\ConsoleLoggerInterface;
+use Accompli\DataCollector\DataCollectorInterface;
+use Accompli\DataCollector\EventDataCollector;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Helper\Table;
+
+/**
+ * AbstractReport.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+abstract class AbstractReport
+{
+    /**
+     * The array with messages used indicate successfulness of a command.
+     *
+     * @var array
+     */
+    protected $messages = array(
+        TitleBlock::STYLE_SUCCESS => '',
+        TitleBlock::STYLE_ERRORED_SUCCESS => '',
+        TitleBlock::STYLE_FAILURE => '',
+    );
+
+    /**
+     * The EventDataCollector instance.
+     *
+     * @var EventDataCollector
+     */
+    private $eventDataCollector;
+
+    /**
+     * The array with data collectors.
+     *
+     * @var DataCollectorInterface[]
+     */
+    private $dataCollectors;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param EventDataCollector $eventDataCollector
+     * @param array              $dataCollectors
+     */
+    public function __construct(EventDataCollector $eventDataCollector, array $dataCollectors)
+    {
+        $this->eventDataCollector = $eventDataCollector;
+        $this->dataCollectors = $dataCollectors;
+    }
+
+    /**
+     * Generates the output for the report.
+     *
+     * @param ConsoleLoggerInterface $logger
+     */
+    public function generate(ConsoleLoggerInterface $logger)
+    {
+        $logLevel = LogLevel::NOTICE;
+        $style = TitleBlock::STYLE_SUCCESS;
+        if ($this->eventDataCollector->hasCountedFailedEvents()) {
+            $logLevel = LogLevel::ERROR;
+            $style = TitleBlock::STYLE_FAILURE;
+        } elseif ($this->eventDataCollector->hasCountedLogLevel(LogLevel::EMERGENCY) || $this->eventDataCollector->hasCountedLogLevel(LogLevel::ALERT) || $this->eventDataCollector->hasCountedLogLevel(LogLevel::CRITICAL) || $this->eventDataCollector->hasCountedLogLevel(LogLevel::ERROR) || $this->eventDataCollector->hasCountedLogLevel(LogLevel::WARNING)) {
+            $logLevel = LogLevel::WARNING;
+            $style = TitleBlock::STYLE_ERRORED_SUCCESS;
+        }
+
+        $output = $logger->getOutput($logLevel);
+
+        $titleBlock = new TitleBlock($output, $this->messages[$style], $style);
+        $titleBlock->render();
+
+        $dataCollectorsData = array();
+        foreach ($this->dataCollectors as $dataCollector) {
+            $data = $dataCollector->getData($logger->getVerbosity());
+            foreach ($data as $label => $value) {
+                $dataCollectorsData[] = array($label, $value);
+            }
+        }
+
+        $table = new Table($output);
+        $table->setRows($dataCollectorsData);
+        $table->setStyle('symfony-style-guide');
+        $table->render();
+
+        $output->writeln('');
+    }
+}

--- a/src/Report/DeployReport.php
+++ b/src/Report/DeployReport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Accompli\Report;
+
+use Accompli\Console\Helper\TitleBlock;
+
+/**
+ * DeployReport.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class DeployReport extends AbstractReport
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $messages = array(
+        TitleBlock::STYLE_SUCCESS => 'Successfully deployed release.',
+        TitleBlock::STYLE_ERRORED_SUCCESS => 'Deployed release. Some errors occured during deployment.',
+        TitleBlock::STYLE_FAILURE => 'Deployment of release failed.',
+    );
+}

--- a/src/Report/InstallReport.php
+++ b/src/Report/InstallReport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Accompli\Report;
+
+use Accompli\Console\Helper\TitleBlock;
+
+/**
+ * InstallReport.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class InstallReport extends AbstractReport
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $messages = array(
+        TitleBlock::STYLE_SUCCESS => 'Successfully installed release.',
+        TitleBlock::STYLE_ERRORED_SUCCESS => 'Installed release. Some errors occured during installation.',
+        TitleBlock::STYLE_FAILURE => 'Installation of release failed.',
+    );
+}

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -17,8 +17,7 @@ services:
         arguments: ["%console.output_interface%"]
     log_subscriber:
         class: Accompli\EventDispatcher\Subscriber\LogSubscriber
-        calls:
-            - [setLogger, ["@logger"]]
+        arguments: ["@logger"]
     log_failure_subscriber:
         class: Accompli\EventDispatcher\Subscriber\LogFailureSubscriber
         arguments: ["@logger"]

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -13,6 +13,7 @@ services:
             - [addSubscriber, ["@log_subscriber"]]
             - [addSubscriber, ["@log_failure_subscriber"]]
             - [addSubscriber, ["@data_collector_subscriber"]]
+            - [addSubscriber, ["@generate_report_subcriber"]]
     logger:
         class: Accompli\Console\Logger\ConsoleLogger
         arguments: ["%console.output_interface%"]
@@ -31,3 +32,6 @@ services:
     data_collector_subscriber:
         class: Accompli\EventDispatcher\Subscriber\DataCollectorSubscriber
         arguments: [["@event_data_collector", "@profiler_data_collector"]]
+    generate_report_subcriber:
+        class: Accompli\EventDispatcher\Subscriber\GenerateReportSubscriber
+        arguments: ["@logger", "@event_data_collector", ["@event_data_collector", "@profiler_data_collector"]]

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -11,6 +11,7 @@ services:
         calls:
             - [addListener, [accompli.create_connection, ["@connection_manager", onCreateConnection]]]
             - [addSubscriber, ["@log_subscriber"]]
+            - [addSubscriber, ["@log_failure_subscriber"]]
     logger:
         class: Accompli\Console\Logger\ConsoleLogger
         arguments: ["%console.output_interface%"]
@@ -18,3 +19,6 @@ services:
         class: Accompli\EventDispatcher\Subscriber\LogSubscriber
         calls:
             - [setLogger, ["@logger"]]
+    log_failure_subscriber:
+        class: Accompli\EventDispatcher\Subscriber\LogFailureSubscriber
+        arguments: ["@logger"]

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -12,12 +12,22 @@ services:
             - [addListener, [accompli.create_connection, ["@connection_manager", onCreateConnection]]]
             - [addSubscriber, ["@log_subscriber"]]
             - [addSubscriber, ["@log_failure_subscriber"]]
+            - [addSubscriber, ["@data_collector_subscriber"]]
     logger:
         class: Accompli\Console\Logger\ConsoleLogger
         arguments: ["%console.output_interface%"]
+
+    profiler_data_collector:
+        class: Accompli\DataCollector\ProfilerDataCollector
+    event_data_collector:
+        class: Accompli\DataCollector\EventDataCollector
+
     log_subscriber:
         class: Accompli\EventDispatcher\Subscriber\LogSubscriber
         arguments: ["@logger"]
     log_failure_subscriber:
         class: Accompli\EventDispatcher\Subscriber\LogFailureSubscriber
         arguments: ["@logger"]
+    data_collector_subscriber:
+        class: Accompli\EventDispatcher\Subscriber\DataCollectorSubscriber
+        arguments: [["@event_data_collector", "@profiler_data_collector"]]

--- a/src/Task/CreateWorkspaceTask.php
+++ b/src/Task/CreateWorkspaceTask.php
@@ -7,8 +7,8 @@ use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
 use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskRuntimeException;
 use Psr\Log\LogLevel;
-use RuntimeException;
 
 /**
  * CreateWorkspaceTask.
@@ -106,7 +106,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
      * @param string                   $eventName
      * @param EventDispatcherInterface $eventDispatcher
      *
-     * @throws RuntimeException
+     * @throws TaskRuntimeException when the workspace path doesn't exist and can't be created.
      */
     public function onPrepareWorkspaceCreateWorkspace(WorkspaceEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -115,7 +115,7 @@ class CreateWorkspaceTask extends AbstractConnectedTask
 
         $workspacePath = $workspace->getHost()->getPath();
         if ($connection->isDirectory($workspacePath) === false && $connection->createDirectory($workspacePath) === false) {
-            throw new RuntimeException(sprintf('The workspace path "%s" does not exist and could not be created.', $workspacePath));
+            throw new TaskRuntimeException(sprintf('The workspace path "%s" does not exist and could not be created.', $workspacePath), $this);
         }
 
         $directories = array_merge(

--- a/src/Task/DeployReleaseTask.php
+++ b/src/Task/DeployReleaseTask.php
@@ -8,8 +8,8 @@ use Accompli\EventDispatcher\Event\DeployReleaseEvent;
 use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent;
 use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskRuntimeException;
 use Psr\Log\LogLevel;
-use RuntimeException;
 
 /**
  * DeployReleaseTask.
@@ -43,7 +43,7 @@ class DeployReleaseTask extends AbstractConnectedTask
      * @param string                    $eventName
      * @param EventDispatcherInterface  $eventDispatcher
      *
-     * @throws RuntimeException when the version selected for deployment is not installed within the workspace.
+     * @throws TaskRuntimeException when the version selected for deployment is not installed within the workspace.
      */
     public function onPrepareDeployReleaseConstructReleaseInstances(PrepareDeployReleaseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -54,7 +54,7 @@ class DeployReleaseTask extends AbstractConnectedTask
         $release = new Release($event->getVersion());
         $workspace->addRelease($release);
         if ($connection->isDirectory($release->getPath()) === false) {
-            throw new RuntimeException(sprintf('The release "%s" is not installed within the workspace.', $release->getVersion()));
+            throw new TaskRuntimeException(sprintf('The release "%s" is not installed within the workspace.', $release->getVersion()), $this);
         }
         $event->setRelease($release);
 
@@ -108,7 +108,7 @@ class DeployReleaseTask extends AbstractConnectedTask
 
                 $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Linking "{linkTarget}" to release "{releaseVersion}" failed.', $eventName, $this, $context));
 
-                throw new RuntimeException(sprintf('Linking "%s" to release "%s" failed.', $context['linkTarget'], $context['releaseVersion']));
+                throw new TaskRuntimeException(sprintf('Linking "%s" to release "%s" failed.', $context['linkTarget'], $context['releaseVersion']), $this);
             }
         } else {
             $context['event.task.action'] = TaskInterface::ACTION_COMPLETED;

--- a/src/Task/ExecuteCommandTask.php
+++ b/src/Task/ExecuteCommandTask.php
@@ -6,6 +6,8 @@ use Accompli\AccompliEvents;
 use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Event\ReleaseEvent;
 use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskCommandExecutionException;
+use Accompli\Exception\TaskRuntimeException;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -74,6 +76,12 @@ class ExecuteCommandTask extends AbstractConnectedTask
 
     /**
      * Executes the configured command.
+     *
+     * @param Event                    $event
+     * @param string                   $eventName
+     * @param EventDispatcherInterface $eventDispatcher
+     *
+     * @throws TaskRuntimeException when execution of the command has failed.
      */
     public function onEvent(Event $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -96,15 +104,14 @@ class ExecuteCommandTask extends AbstractConnectedTask
 
             $connection->changeWorkingDirectory($path);
             $result = $connection->executeCommand($this->command, $this->arguments);
+            $connection->changeWorkingDirectory($currentWorkingDirectory);
+
             if ($result->isSuccessful()) {
                 $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Executed command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_COMPLETED, 'output.resetLine' => true)));
+                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
             } else {
-                $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::WARNING, 'Failed executing command "{command}".', $eventName, $this, array('command' => $this->command, 'event.task.action' => TaskInterface::ACTION_FAILED, 'output.resetLine' => true)));
+                throw new TaskCommandExecutionException(sprintf('Failed executing command "%s".', $this->command), $result, $this);
             }
-
-            $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::DEBUG, "{separator} Command output:{separator}\n{command.result}{separator}", $eventName, $this, array('command.result' => $result->getOutput(), 'separator' => "\n=================\n")));
-
-            $connection->changeWorkingDirectory($currentWorkingDirectory);
         }
     }
 }

--- a/src/Task/MaintenanceModeTask.php
+++ b/src/Task/MaintenanceModeTask.php
@@ -7,10 +7,10 @@ use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
 use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskRuntimeException;
 use Accompli\Utility\VersionCategoryComparator;
 use InvalidArgumentException;
 use Psr\Log\LogLevel;
-use RuntimeException;
 
 /**
  * MaintenanceModeTask.
@@ -123,7 +123,7 @@ class MaintenanceModeTask extends AbstractConnectedTask
      * @param string                    $eventName
      * @param EventDispatcherInterface  $eventDispatcher
      *
-     * @throws RuntimeException when not able to link the maintenance page.
+     * @throws TaskRuntimeException when not able to link the maintenance page.
      */
     public function onPrepareDeployReleaseLinkMaintenancePageToStage(PrepareDeployReleaseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -159,7 +159,7 @@ class MaintenanceModeTask extends AbstractConnectedTask
 
             $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'Linking "{linkTarget}" to maintenance page failed.', $eventName, $this, $context));
 
-            throw new RuntimeException(sprintf('Linking "%s" to maintenance page failed.', $context['linkTarget']));
+            throw new TaskRuntimeException(sprintf('Linking "%s" to maintenance page failed.', $context['linkTarget']), $this);
         }
     }
 }

--- a/src/Task/RepositoryCheckoutTask.php
+++ b/src/Task/RepositoryCheckoutTask.php
@@ -9,8 +9,8 @@ use Accompli\Deployment\Release;
 use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Event\PrepareReleaseEvent;
 use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskRuntimeException;
 use Psr\Log\LogLevel;
-use RuntimeException;
 
 /**
  * RepositoryCheckoutTask.
@@ -71,7 +71,7 @@ class RepositoryCheckoutTask extends AbstractConnectedTask
      * @param string                   $eventName
      * @param EventDispatcherInterface $eventDispatcher
      *
-     * @throws RuntimeException
+     * @throws TaskRuntimeException when the checkout of the repository has failed.
      */
     public function onPrepareReleaseCheckoutRepository(PrepareReleaseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -89,7 +89,7 @@ class RepositoryCheckoutTask extends AbstractConnectedTask
 
             $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::NOTICE, 'Created checkout of repository "{repositoryUrl}" for version "{version}".', $eventName, $this, $context));
         } else {
-            throw new RuntimeException(sprintf('Checkout of repository "%s" for version "%s" failed.', $this->repositoryUrl, $event->getRelease()->getVersion()));
+            throw new TaskRuntimeException(sprintf('Failed to checkout version "%s" from repository "%s".', $event->getRelease()->getVersion(), $this->repositoryUrl), $this);
         }
     }
 }

--- a/tests/AccompliTest.php
+++ b/tests/AccompliTest.php
@@ -137,11 +137,22 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
+        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+                ->getMock();
+        $eventDispatcherMock->expects($this->once())
+                ->method('dispatch');
+
         $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $containerMock->expects($this->once())
+        $containerMock->expects($this->exactly(2))
                 ->method('get')
-                ->with($this->equalTo('deployment_strategy'))
-                ->willReturn($deploymentStrategyMock);
+                ->withConsecutive(
+                    array($this->equalTo('deployment_strategy')),
+                    array($this->equalTo('event_dispatcher'))
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $deploymentStrategyMock,
+                    $eventDispatcherMock
+                );
 
         $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
 
@@ -149,7 +160,9 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 ->setConstructorArgs(array($parameterBagMock))
                 ->setMethods(array('getContainer'))
                 ->getMock();
-        $accompli->expects($this->once())->method('getContainer')->willReturn($containerMock);
+        $accompli->expects($this->exactly(2))
+                ->method('getContainer')
+                ->willReturn($containerMock);
 
         $this->assertTrue($accompli->install('0.1.0'));
     }
@@ -168,11 +181,22 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
+        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+                ->getMock();
+        $eventDispatcherMock->expects($this->once())
+                ->method('dispatch');
+
         $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $containerMock->expects($this->once())
+        $containerMock->expects($this->exactly(2))
                 ->method('get')
-                ->with($this->equalTo('deployment_strategy'))
-                ->willReturn($deploymentStrategyMock);
+                ->withConsecutive(
+                    array($this->equalTo('deployment_strategy')),
+                    array($this->equalTo('event_dispatcher'))
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $deploymentStrategyMock,
+                    $eventDispatcherMock
+                );
 
         $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
 
@@ -180,7 +204,9 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 ->setConstructorArgs(array($parameterBagMock))
                 ->setMethods(array('getContainer'))
                 ->getMock();
-        $accompli->expects($this->once())->method('getContainer')->willReturn($containerMock);
+        $accompli->expects($this->exactly(2))
+                ->method('getContainer')
+                ->willReturn($containerMock);
 
         $this->assertTrue($accompli->deploy('0.1.0', Host::STAGE_TEST));
     }

--- a/tests/Console/Helper/TitleBlockTest.php
+++ b/tests/Console/Helper/TitleBlockTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Accompli\Test\Console\Helper;
+
+use Accompli\Console\Helper\TitleBlock;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
+/**
+ * TitleBlockTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TitleBlockTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if constructing a new TitleBlock instance sets the properties.
+     */
+    public function testConstruct()
+    {
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+
+        $titleBlock = new TitleBlock($outputMock, 'Test message', TitleBlock::STYLE_SUCCESS);
+
+        $this->assertAttributeSame($outputMock, 'output', $titleBlock);
+        $this->assertAttributeSame('Test message', 'message', $titleBlock);
+        $this->assertAttributeSame(TitleBlock::STYLE_SUCCESS, 'style', $titleBlock);
+    }
+
+    /**
+     * Tests if TitleBlock::render writes the lines to the output instance to render a title block.
+     *
+     * @dataProvider provideTestRender
+     *
+     * @param string $style
+     * @param string $beforeAfterLine
+     * @param string $messageLine
+     */
+    public function testRender($style, $beforeAfterLine, $messageLine)
+    {
+        $outputFormatter = new OutputFormatter();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->exactly(3))
+                ->method('getFormatter')
+                ->willReturn($outputFormatter);
+        $outputMock->expects($this->exactly(5))
+                ->method('writeln')
+                ->withConsecutive(
+                    array($this->equalTo('')),
+                    array($this->stringStartsWith($beforeAfterLine)),
+                    array($this->stringStartsWith($messageLine)),
+                    array($this->stringStartsWith($beforeAfterLine)),
+                    array($this->equalTo(''))
+                );
+
+        $title = new TitleBlock($outputMock, 'Test message', $style);
+        $title->render();
+    }
+
+    /**
+     * Returns an array with the different TitleBlock styles and the expected output for testing @see testRender.
+     *
+     * @return array
+     */
+    public function provideTestRender()
+    {
+        return array(
+            array(TitleBlock::STYLE_SUCCESS, '<fg=black;bg=green>', '<fg=black;bg=green> [OK] Test message'),
+            array(TitleBlock::STYLE_ERRORED_SUCCESS, '<fg=black;bg=yellow>', '<fg=black;bg=yellow> [OK, but with errors] Test message'),
+            array(TitleBlock::STYLE_FAILURE, '<fg=white;bg=red>', '<fg=white;bg=red> [FAILURE] Test message'),
+        );
+    }
+}

--- a/tests/Console/Helper/TitleTest.php
+++ b/tests/Console/Helper/TitleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Accompli\Test\Console\Helper;
+
+use Accompli\Console\Helper\Title;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
+/**
+ * TitleTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TitleTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if constructing a new Title instance sets the properties.
+     */
+    public function testConstruct()
+    {
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+
+        $title = new Title($outputMock, 'Test message');
+
+        $this->assertAttributeSame($outputMock, 'output', $title);
+        $this->assertAttributeSame('Test message', 'message', $title);
+    }
+
+    /**
+     * Tests if TitleBlock::render writes the lines to the output instance to render a title.
+     */
+    public function testRender()
+    {
+        $outputFormatter = new OutputFormatter();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatter);
+        $outputMock->expects($this->once())
+                ->method('writeln')
+                ->with(
+                    $this->equalTo(
+                        array(
+                            '',
+                            '<title>Test message</>',
+                            '<title>============</>',
+                            '',
+                        )
+                    )
+                );
+
+        $title = new Title($outputMock, 'Test message');
+        $title->render();
+    }
+}

--- a/tests/Console/Logger/ConsoleLoggerTest.php
+++ b/tests/Console/Logger/ConsoleLoggerTest.php
@@ -53,6 +53,54 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if ConsoleLogger::getVerbosity returns the verbosity from the output instance.
+     */
+    public function testGetVerbosity()
+    {
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+
+        $logger = new ConsoleLogger($outputMock);
+
+        $this->assertSame(OutputInterface::VERBOSITY_NORMAL, $logger->getVerbosity());
+    }
+
+    /**
+     * Tests if ConsoleLogger::getOutput returns the output instance.
+     */
+    public function testGetOutput()
+    {
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+
+        $logger = new ConsoleLogger($outputMock);
+
+        $this->assertSame($outputMock, $logger->getOutput());
+    }
+
+    /**
+     * Tests if ConsoleLogger::getOutput returns the error output instance when the log level is an error log level.
+     */
+    public function testGetOutputReturnsErrorOutput()
+    {
+        $errorOutputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getErrorOutput')
+                ->willReturn($errorOutputMock);
+
+        $logger = new ConsoleLogger($outputMock);
+
+        $this->assertSame($errorOutputMock, $logger->getOutput(LogLevel::ERROR));
+    }
+
+    /**
      * Tests if ConsoleLogger::log with an invalid LogLevel throws an InvalidArgumentException.
      *
      * @expectedException        InvalidArgumentException

--- a/tests/DataCollector/EventDataCollectorTest.php
+++ b/tests/DataCollector/EventDataCollectorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Accompli\Test\DataCollector;
+
+use Accompli\AccompliEvents;
+use Accompli\DataCollector\EventDataCollector;
+use PHPUnit_Framework_TestCase;
+use Psr\Log\LogLevel;
+
+/**
+ * EventDataCollectorTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class EventDataCollectorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if EventDataCollector::collect increments the log level count when receiving a LogEvent instance.
+     */
+    public function testCollectLogEvent()
+    {
+        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $eventMock->expects($this->once())
+                ->method('getLevel')
+                ->willReturn(LogLevel::NOTICE);
+
+        $dataCollector = new EventDataCollector();
+        $dataCollector->collect($eventMock, AccompliEvents::LOG);
+
+        $expected = array(
+            LogLevel::EMERGENCY => 0,
+            LogLevel::ALERT => 0,
+            LogLevel::CRITICAL => 0,
+            LogLevel::ERROR => 0,
+            LogLevel::WARNING => 0,
+            LogLevel::NOTICE => 1,
+            LogLevel::INFO => 0,
+            LogLevel::DEBUG => 0,
+        );
+
+        $this->assertAttributeSame($expected, 'logLevelCount', $dataCollector);
+    }
+
+    /**
+     * Tests if EventDataCollector::collect increments the failed event count when receiving a FailedEvent instance.
+     */
+    public function testCollectFailedEvent()
+    {
+        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $dataCollector = new EventDataCollector();
+        $dataCollector->collect($eventMock, AccompliEvents::INSTALL_RELEASE_FAILED);
+    }
+
+    /**
+     * Tests if EventDataCollector::hasCountedLogLevel returns false.
+     */
+    public function testHasCountedLogLevelReturnsFalse()
+    {
+        $dataCollector = new EventDataCollector();
+
+        $this->assertFalse($dataCollector->hasCountedLogLevel(LogLevel::NOTICE));
+    }
+
+    /**
+     * Tests if EventDataCollector::hasCountedLogLevel returns false for a non-existing log level.
+     */
+    public function testHasCountedLogLevelReturnsFalseOnNonExistingLogLevel()
+    {
+        $dataCollector = new EventDataCollector();
+
+        $this->assertFalse($dataCollector->hasCountedLogLevel('doesnotexist'));
+    }
+
+    /**
+     * Tests if EventDataCollector::hasCountedLogLevel returns true when a requested log level has been counted.
+     */
+    public function testHasCountedLogLevelReturnsTrueWhenCountedLogLevels()
+    {
+        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $eventMock->expects($this->once())
+                ->method('getLevel')
+                ->willReturn(LogLevel::NOTICE);
+
+        $dataCollector = new EventDataCollector();
+        $dataCollector->collect($eventMock, AccompliEvents::LOG);
+
+        $this->assertTrue($dataCollector->hasCountedLogLevel(LogLevel::NOTICE));
+    }
+
+    /**
+     * Tests if EventDataCollector::hasCountedFailedEvents returns false.
+     */
+    public function testHasCountedFailedEventsReturnsFalse()
+    {
+        $dataCollector = new EventDataCollector();
+
+        $this->assertFalse($dataCollector->hasCountedFailedEvents());
+    }
+
+    /**
+     * Tests if EventDataCollector::hasCountedFailedEvents returns true when a FailedEvent has been counted.
+     */
+    public function testHasCountedFailedEventsReturnsTrueWhenCountedFailedEvents()
+    {
+        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $dataCollector = new EventDataCollector();
+        $dataCollector->collect($eventMock, AccompliEvents::INSTALL_RELEASE_FAILED);
+
+        $this->assertTrue($dataCollector->hasCountedFailedEvents());
+    }
+
+    /**
+     * Tests if EventDataCollector::getData returns an empty array.
+     */
+    public function testGetData()
+    {
+        $dataCollector = new EventDataCollector();
+
+        $this->assertInternalType('array', $dataCollector->getData());
+        $this->assertEmpty($dataCollector->getData());
+    }
+}

--- a/tests/DataCollector/ProfilerDataCollectorTest.php
+++ b/tests/DataCollector/ProfilerDataCollectorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Accompli\Test\DataCollector;
+
+use Accompli\AccompliEvents;
+use Accompli\DataCollector\ProfilerDataCollector;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * ProfilerDataCollectorTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ProfilerDataCollectorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if ProfilerDataCollector::collect sets the start DateTime instance.
+     */
+    public function testCollectInitialize()
+    {
+        $dataCollector = new ProfilerDataCollector();
+        $dataCollector->collect(new Event(), AccompliEvents::INITIALIZE);
+
+        $this->assertAttributeInstanceOf('DateTime', 'start', $dataCollector);
+    }
+
+    /**
+     * Test if ProfilerDataCollector::collect sets the end DateTime instance and peak memory usage.
+     *
+     * @dataProvider provideCommandCompleteEventNames
+     *
+     * @param string $commandCompleteEventName
+     */
+    public function testCollectCommandComplete($commandCompleteEventName)
+    {
+        $dataCollector = new ProfilerDataCollector();
+        $dataCollector->collect(new Event(), $commandCompleteEventName);
+
+        $this->assertAttributeInstanceOf('DateTime', 'end', $dataCollector);
+        $this->assertAttributeGreaterThan(0, 'peakMemoryUsage', $dataCollector);
+    }
+
+    /**
+     * Tests if ProfilerDataCollector::getData returns an empty array at normal verbosity.
+     */
+    public function testGetDataReturnsEmptyArray()
+    {
+        $dataCollector = new ProfilerDataCollector();
+
+        $this->assertInternalType('array', $dataCollector->getData());
+        $this->assertEmpty($dataCollector->getData());
+    }
+
+    /**
+     * Tests if ProfilerDataCollector::getData returns an array with execution time at verbose verbosity.
+     */
+    public function testGetDataAtVerbosityVerbose()
+    {
+        $dataCollector = new ProfilerDataCollector();
+        $dataCollector->collect(new Event(), AccompliEvents::INITIALIZE);
+        $dataCollector->collect(new Event(), AccompliEvents::INSTALL_COMMAND_COMPLETE);
+
+        $this->assertInternalType('array', $dataCollector->getData(OutputInterface::VERBOSITY_VERBOSE));
+        $this->assertArrayHasKey('Execution time', $dataCollector->getData(OutputInterface::VERBOSITY_VERBOSE));
+    }
+
+    /**
+     * Tests if ProfilerDataCollector::getData returns an array with an unknown execution time when for some reason the event were not collected.
+     */
+    public function testGetDataWithoutCollectedEventsAtVerbosityVerbose()
+    {
+        $dataCollector = new ProfilerDataCollector();
+
+        $this->assertInternalType('array', $dataCollector->getData(OutputInterface::VERBOSITY_VERBOSE));
+        $this->assertSame(array('Execution time' => 'Unknown'), $dataCollector->getData(OutputInterface::VERBOSITY_VERBOSE));
+    }
+
+    /**
+     * Tests if ProfilerDataCollector::getData returns an array with execution time and peak memory usage at debug verbosity.
+     */
+    public function testGetDataAtVerbosityDebug()
+    {
+        $dataCollector = new ProfilerDataCollector();
+        $dataCollector->collect(new Event(), AccompliEvents::INITIALIZE);
+        $dataCollector->collect(new Event(), AccompliEvents::INSTALL_COMMAND_COMPLETE);
+
+        $this->assertInternalType('array', $dataCollector->getData(OutputInterface::VERBOSITY_DEBUG));
+        $this->assertArrayHasKey('Execution time', $dataCollector->getData(OutputInterface::VERBOSITY_DEBUG));
+    }
+
+    /**
+     * Returns an array with command complete event names.
+     *
+     * @return array
+     */
+    public function provideCommandCompleteEventNames()
+    {
+        return array(
+            array(AccompliEvents::INSTALL_COMMAND_COMPLETE),
+            array(AccompliEvents::DEPLOY_COMMAND_COMPLETE),
+        );
+    }
+}

--- a/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
+++ b/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
@@ -46,6 +46,21 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if AbstractDeploymentStrategy::setLogger sets the logger property of the class.
+     */
+    public function testSetLogger()
+    {
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')
+                ->getMockForAbstractClass();
+
+        $deploymentStrategyMock->setLogger($loggerMock);
+
+        $this->assertAttributeSame($loggerMock, 'logger', $deploymentStrategyMock);
+    }
+
+    /**
      * Tests if AbstractDeploymentStrategy::deploy dispatches all the events successfully.
      *
      * @depends testSetConfiguration

--- a/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
+++ b/tests/Deployment/Strategy/AbstractDeploymentStrategyTest.php
@@ -110,9 +110,25 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
         $strategyMock->setConfiguration($configurationMock);
         $strategyMock->setEventDispatcher($eventDispatcherMock);
+        $strategyMock->setLogger($loggerMock);
 
         $this->assertTrue($strategyMock->deploy('0.1.0', Host::STAGE_TEST));
     }
@@ -192,9 +208,25 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->exactly(2))
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->exactly(2))
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
         $strategyMock->setConfiguration($configurationMock);
         $strategyMock->setEventDispatcher($eventDispatcherMock);
+        $strategyMock->setLogger($loggerMock);
 
         $this->assertTrue($strategyMock->deploy('0.1.0', Host::STAGE_TEST));
     }
@@ -244,9 +276,25 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
         $strategyMock->setConfiguration($configurationMock);
         $strategyMock->setEventDispatcher($eventDispatcherMock);
+        $strategyMock->setLogger($loggerMock);
 
         $this->assertFalse($strategyMock->deploy('0.1.0', Host::STAGE_TEST));
     }
@@ -300,9 +348,25 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
         $strategyMock->setConfiguration($configurationMock);
         $strategyMock->setEventDispatcher($eventDispatcherMock);
+        $strategyMock->setLogger($loggerMock);
 
         $this->assertFalse($strategyMock->deploy('0.1.0', Host::STAGE_TEST));
     }
@@ -356,9 +420,25 @@ class AbstractDeploymentStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\AbstractDeploymentStrategy')->getMockForAbstractClass();
         $strategyMock->setConfiguration($configurationMock);
         $strategyMock->setEventDispatcher($eventDispatcherMock);
+        $strategyMock->setLogger($loggerMock);
 
         $this->assertTrue($strategyMock->deploy('0.1.0', Host::STAGE_TEST));
     }

--- a/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
+++ b/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
@@ -104,9 +104,25 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategy = new RemoteInstallStrategy();
         $strategy->setConfiguration($configurationMock);
         $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->setLogger($loggerMock);
 
         $this->assertTrue($strategy->install('0.1.0', Host::STAGE_TEST));
     }
@@ -185,9 +201,25 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->exactly(2))
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->exactly(2))
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategy = new RemoteInstallStrategy();
         $strategy->setConfiguration($configurationMock);
         $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->setLogger($loggerMock);
 
         $this->assertTrue($strategy->install('0.1.0', Host::STAGE_TEST));
     }
@@ -241,9 +273,25 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategy = new RemoteInstallStrategy();
         $strategy->setConfiguration($configurationMock);
         $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->setLogger($loggerMock);
 
         $this->assertFalse($strategy->install('0.1.0', Host::STAGE_TEST));
     }
@@ -293,9 +341,25 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
         $strategy = new RemoteInstallStrategy();
         $strategy->setConfiguration($configurationMock);
         $strategy->setEventDispatcher($eventDispatcherMock);
+        $strategy->setLogger($loggerMock);
 
         $this->assertFalse($strategy->install('0.1.0', Host::STAGE_TEST));
     }

--- a/tests/EventDispatcher/Event/FailedEventTest.php
+++ b/tests/EventDispatcher/Event/FailedEventTest.php
@@ -19,15 +19,27 @@ class FailedEventTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider provideConstructSetsProperties
      *
+     * @param string    $eventName
      * @param Event     $event
      * @param Exception $exception
      */
-    public function testConstructSetsProperties($event, $exception)
+    public function testConstructSetsProperties($eventName, $event, $exception)
     {
-        $failedEvent = new FailedEvent($event, $exception);
+        $failedEvent = new FailedEvent($eventName, $event, $exception);
 
+        $this->assertAttributeSame($eventName, 'eventName', $failedEvent);
         $this->assertAttributeSame($event, 'event', $failedEvent);
         $this->assertAttributeSame($exception, 'exception', $failedEvent);
+    }
+
+    /**
+     * Tests if FailedEvent::getLastEventName returns the same value as during construction of FailedEvent.
+     */
+    public function testGetLastEventName()
+    {
+        $failedEvent = new FailedEvent('event', new Event());
+
+        $this->assertSame('event', $failedEvent->getLastEventName());
     }
 
     /**
@@ -37,7 +49,7 @@ class FailedEventTest extends PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $failedEvent = new FailedEvent($event);
+        $failedEvent = new FailedEvent('event', $event);
 
         $this->assertSame($event, $failedEvent->getLastEvent());
     }
@@ -47,7 +59,7 @@ class FailedEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExceptionReturnsNullByDefault()
     {
-        $failedEvent = new FailedEvent(new Event());
+        $failedEvent = new FailedEvent('event', new Event());
 
         $this->assertNull($failedEvent->getException());
     }
@@ -59,7 +71,7 @@ class FailedEventTest extends PHPUnit_Framework_TestCase
     {
         $exception = new Exception();
 
-        $failedEvent = new FailedEvent(new Event(), $exception);
+        $failedEvent = new FailedEvent('event', new Event(), $exception);
 
         $this->assertSame($exception, $failedEvent->getException());
     }
@@ -72,8 +84,8 @@ class FailedEventTest extends PHPUnit_Framework_TestCase
     public function provideConstructSetsProperties()
     {
         return array(
-            array(new Event(), null),
-            array(new Event(), new Exception()),
+            array('event', new Event(), null),
+            array('event', new Event(), new Exception()),
         );
     }
 }

--- a/tests/EventDispatcher/EventDispatcherTest.php
+++ b/tests/EventDispatcher/EventDispatcherTest.php
@@ -2,8 +2,11 @@
 
 namespace Accompli\Test\EventDispatcher;
 
+use Accompli\AccompliEvents;
+use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\EventDispatcher;
 use PHPUnit_Framework_TestCase;
+use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -13,6 +16,38 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class EventDispatcherTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * Tests if EventDispatcher::getLastDispatchedEventName returns null when no event has been dispatched.
+     */
+    public function testGetLastDispatchedEventNameReturnsNullWithoutDispatchCalled()
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        $this->assertNull($eventDispatcher->getLastDispatchedEventName());
+    }
+
+    /**
+     * Tests if EventDispatcher::getLastDispatchedEventName returns the same event instance that was dispatched.
+     */
+    public function testGetLastDispatchedEventNameReturnsSameEventInstance()
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->dispatch('test', new Event());
+
+        $this->assertSame('test', $eventDispatcher->getLastDispatchedEventName());
+    }
+
+    /**
+     * Tests if EventDispatcher::getLastDispatchedEventName does not return a AccompliEvents::LOG event.
+     */
+    public function testGetLastDispatchedEventNameNeverReturnsLogEvent()
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'message', 'eventName'));
+
+        $this->assertNull($eventDispatcher->getLastDispatchedEventName());
+    }
+
     /**
      * Tests if EventDispatcher::getLastDispatchedEvent returns null when no event has been dispatched.
      */
@@ -33,8 +68,7 @@ class EventDispatcherTest extends PHPUnit_Framework_TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->dispatch('test', $event);
 
-        $lastDispatchedEvent = $eventDispatcher->getLastDispatchedEvent();
-        $this->assertSame($event, $lastDispatchedEvent);
+        $this->assertSame($event, $eventDispatcher->getLastDispatchedEvent());
     }
 
     /**
@@ -45,7 +79,17 @@ class EventDispatcherTest extends PHPUnit_Framework_TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->dispatch('test');
 
-        $lastDispatchedEvent = $eventDispatcher->getLastDispatchedEvent();
-        $this->assertInstanceOf('Symfony\Component\EventDispatcher\Event', $lastDispatchedEvent);
+        $this->assertInstanceOf('Symfony\Component\EventDispatcher\Event', $eventDispatcher->getLastDispatchedEvent());
+    }
+
+    /**
+     * Tests if EventDispatcher::getLastDispatchedEvent does not return a AccompliEvents::LOG event.
+     */
+    public function testGetLastDispatchedEventNeverReturnsLogEvent()
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->dispatch(AccompliEvents::LOG, new LogEvent(LogLevel::INFO, 'message', 'eventName'));
+
+        $this->assertNull($eventDispatcher->getLastDispatchedEvent());
     }
 }

--- a/tests/EventDispatcher/Subscriber/DataCollectorSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/DataCollectorSubscriberTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Accompli\Test\EventDispatcher\Subscriber;
+
+use Accompli\EventDispatcher\Subscriber\DataCollectorSubscriber;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * DataCollectorSubscriberTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class DataCollectorSubscriberTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if DataCollectorSubscriber::getSubscribedEvents returns an array with AccompliEvents keys.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $this->assertInternalType('array', DataCollectorSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * Tests if constructing a new DataCollectorSubscriber instance sets the properties.
+     */
+    public function testConstruct()
+    {
+        $dataSubscriber = new DataCollectorSubscriber(array());
+
+        $this->assertAttributeSame(array(), 'dataCollectors', $dataSubscriber);
+    }
+
+    /**
+     * Tests if DataCollectorSubscriber::addDataCollector adds a data collector instance to the data collectors.
+     *
+     * @depends testConstruct
+     */
+    public function testAddDataCollector()
+    {
+        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+                ->getMock();
+
+        $dataSubscriber = new DataCollectorSubscriber(array());
+        $dataSubscriber->addDataCollector($dataCollectorMock);
+
+        $this->assertAttributeSame(array($dataCollectorMock), 'dataCollectors', $dataSubscriber);
+    }
+
+    /**
+     * Tests if DataCollectorSubscriber::onEvent calls the collect method on all data collector instances.
+     *
+     * @depends testConstruct
+     */
+    public function testOnEvent()
+    {
+        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+                ->getMock();
+        $dataCollectorMock->expects($this->once())
+                ->method('collect');
+
+        $dataSubscriber = new DataCollectorSubscriber(array($dataCollectorMock));
+        $dataSubscriber->onEvent(new Event(), 'accompli.test');
+    }
+}

--- a/tests/EventDispatcher/Subscriber/GenerateReportSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/GenerateReportSubscriberTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Accompli\Test\EventDispatcher\Subscriber;
+
+use Accompli\AccompliEvents;
+use Accompli\EventDispatcher\Subscriber\GenerateReportSubscriber;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * GenerateReportSubscriberTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class GenerateReportSubscriberTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if GenerateReportSubscriber::getSubscribedEvents returns an array with AccompliEvent command complete keys.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $this->assertInternalType('array', GenerateReportSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::INSTALL_COMMAND_COMPLETE, GenerateReportSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::DEPLOY_COMMAND_COMPLETE, GenerateReportSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * Tests if constructing a new GenerateReportSubscriber instance sets the properties.
+     */
+    public function testConstruct()
+    {
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+
+        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+                ->getMock();
+
+        $subscriber = new GenerateReportSubscriber($loggerMock, $eventDataCollectorMock, array());
+
+        $this->assertAttributeSame($loggerMock, 'logger', $subscriber);
+        $this->assertAttributeSame($eventDataCollectorMock, 'eventDataCollector', $subscriber);
+        $this->assertAttributeSame(array(), 'dataCollectors', $subscriber);
+    }
+}

--- a/tests/EventDispatcher/Subscriber/LogFailureSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/LogFailureSubscriberTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Accompli\Test\EventDispatcher\Subscriber;
+
+use Accompli\AccompliEvents;
+use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\EventDispatcher\Subscriber\LogFailureSubscriber;
+use Accompli\Exception\TaskCommandExecutionException;
+use Accompli\Task\CreateWorkspaceTask;
+use PHPUnit_Framework_TestCase;
+use Psr\Log\LogLevel;
+
+/**
+ * LogFailureSubscriberTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class LogFailureSubscriberTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if LogFailureSubscriber::getSubscribedEvents returns an array with AccompliEvents keys.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $this->assertInternalType('array', LogFailureSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::INSTALL_RELEASE_FAILED, LogFailureSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::DEPLOY_RELEASE_FAILED, LogFailureSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(AccompliEvents::ROLLBACK_RELEASE_FAILED, LogFailureSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * Tests if constructing a new LogFailureSubscriber instance sets the logger property.
+     */
+    public function testConstruct()
+    {
+        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $logSubscriber = new LogFailureSubscriber($loggerMock);
+
+        $this->assertAttributeSame($loggerMock, 'logger', $logSubscriber);
+    }
+
+    /**
+     * Tests if LogFailureSubscriber::onFailedEventLogToLogger calls the log method on the logger.
+     *
+     * @depends testConstruct
+     */
+    public function testOnFailedEventLogToLogger()
+    {
+        $failedEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $failedEventMock->expects($this->once())
+                ->method('getLastEventName')
+                ->willReturn('accompli.test');
+
+        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('log')
+                ->with(
+                    $this->equalTo(LogLevel::CRITICAL),
+                    $this->equalTo('An unknown error occured.'),
+                    $this->equalTo(array('event.name' => 'accompli.test'))
+                );
+
+        $logSubscriber = new LogFailureSubscriber($loggerMock);
+        $logSubscriber->onFailedEventLogToLogger($failedEventMock);
+    }
+
+    /**
+     * Tests if LogFailureSubscriber::onFailedEventLogToLogger calls the log method on the logger.
+     *
+     * @depends testConstruct
+     */
+    public function testOnFailedEventLogToLoggerWithTaskCommandExecutionException()
+    {
+        $task = new CreateWorkspaceTask();
+
+        $taskCommandExecutionException = new TaskCommandExecutionException('Test exception.', new ProcessExecutionResult(1, 'Command output.', ''), $task);
+
+        $failedEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $failedEventMock->expects($this->once())
+                ->method('getLastEventName')
+                ->willReturn('accompli.test');
+        $failedEventMock->expects($this->once())
+                ->method('getException')
+                ->willReturn($taskCommandExecutionException);
+
+        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->exactly(2))
+                ->method('log')
+                ->withConsecutive(
+                    array(
+                        $this->equalTo(LogLevel::CRITICAL),
+                        $this->equalTo('Test exception.'),
+                        $this->equalTo(array(
+                            'event.name' => 'accompli.test',
+                            'event.task.name' => 'CreateWorkspaceTask',
+                        )),
+                    ),
+                    array(
+                        $this->equalTo(LogLevel::DEBUG),
+                        $this->equalTo("{separator} Command output:{separator}\n{command.result}{separator}"),
+                        $this->equalTo(array(
+                            'event.name' => 'accompli.test',
+                            'event.task.name' => 'CreateWorkspaceTask',
+                            'command.result' => 'Command output.',
+                            'separator' => "\n=================\n",
+                        )),
+                    )
+                );
+
+        $logSubscriber = new LogFailureSubscriber($loggerMock);
+        $logSubscriber->onFailedEventLogToLogger($failedEventMock);
+    }
+}

--- a/tests/EventDispatcher/Subscriber/LogSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/LogSubscriberTest.php
@@ -25,14 +25,13 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests if LogSubscriber::setLogger sets the logger property.
+     * Tests if constructing a new LogSubscriber instance sets the logger property.
      */
-    public function testSetLogger()
+    public function testConstruct()
     {
         $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
-        $logSubscriber = new LogSubscriber();
-        $logSubscriber->setLogger($loggerMock);
+        $logSubscriber = new LogSubscriber($loggerMock);
 
         $this->assertAttributeSame($loggerMock, 'logger', $logSubscriber);
     }
@@ -40,7 +39,7 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
     /**
      * Tests if LogSubscriber::onLogEvent calls the log method on the logger.
      *
-     * @depends testSetLogger
+     * @depends testConstruct
      */
     public function testOnLogEvent()
     {
@@ -64,15 +63,14 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
                     $this->equalTo(array('event.name' => 'accompli.test', 'event.task.name' => get_class($eventSubscriberMock)))
                 );
 
-        $logSubscriber = new LogSubscriber();
-        $logSubscriber->setLogger($loggerMock);
+        $logSubscriber = new LogSubscriber($loggerMock);
         $logSubscriber->onLogEvent($logEventMock);
     }
 
     /**
      * Tests if LogSubscriber::onLogEvent calls the log method on the logger.
      *
-     * @depends testSetLogger
+     * @depends testConstruct
      */
     public function testOnLogEventWithNamespacedEventSubscriber()
     {
@@ -96,8 +94,7 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
                     $this->equalTo(array('event.name' => 'accompli.test', 'event.task.name' => 'CreateWorkspaceTask'))
                 );
 
-        $logSubscriber = new LogSubscriber();
-        $logSubscriber->setLogger($loggerMock);
+        $logSubscriber = new LogSubscriber($loggerMock);
         $logSubscriber->onLogEvent($logEventMock);
     }
 }

--- a/tests/Exception/TaskCommandExecutionExceptionTest.php
+++ b/tests/Exception/TaskCommandExecutionExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Accompli\Test\Exception;
+
+use Accompli\Exception\TaskCommandExecutionException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * TaskCommandExecutionExceptionTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TaskCommandExecutionExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if constructing a new TaskCommandExecutionException sets the properties.
+     */
+    public function testConstruct()
+    {
+        $processExecutionResultMock = $this->getMockBuilder('Accompli\Chrono\Process\ProcessExecutionResult')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+                ->getMock();
+
+        $exception = new TaskCommandExecutionException('Test exception', $processExecutionResultMock, $taskMock);
+
+        $this->assertAttributeSame('Test exception', 'message', $exception);
+        $this->assertAttributeSame($taskMock, 'task', $exception);
+        $this->assertAttributeSame($processExecutionResultMock, 'processExecutionResult', $exception);
+    }
+
+    /**
+     * Tests if TaskCommandExecutionException::getProcessExecutionResult returns the ProcessExecutionResult instance set in the constructor.
+     *
+     * @depends testConstruct
+     */
+    public function testGetProcessExecutionResult()
+    {
+        $processExecutionResultMock = $this->getMockBuilder('Accompli\Chrono\Process\ProcessExecutionResult')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $exception = new TaskCommandExecutionException('Test exception', $processExecutionResultMock);
+
+        $this->assertSame($processExecutionResultMock, $exception->getProcessExecutionResult());
+    }
+}

--- a/tests/Exception/TaskRuntimeExceptionTest.php
+++ b/tests/Exception/TaskRuntimeExceptionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Accompli\Test\Exception;
+
+use Accompli\Exception\TaskRuntimeException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * TaskRuntimeExceptionTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TaskRuntimeExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if constructing a new TaskRuntimeException sets the properties.
+     */
+    public function testConstruct()
+    {
+        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+                ->getMock();
+
+        $exception = new TaskRuntimeException('Test exception', $taskMock);
+
+        $this->assertAttributeSame('Test exception', 'message', $exception);
+        $this->assertAttributeSame($taskMock, 'task', $exception);
+    }
+
+    /**
+     * Tests if TaskRuntimeException::getTask returns the task instance set in the constructor.
+     *
+     * @depends testConstruct
+     */
+    public function testGetTask()
+    {
+        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+                ->getMock();
+
+        $exception = new TaskRuntimeException('Test exception', $taskMock);
+
+        $this->assertSame($taskMock, $exception->getTask());
+    }
+}

--- a/tests/Report/AbstractReportTest.php
+++ b/tests/Report/AbstractReportTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Accompli\Test\Report;
+
+use Accompli\DataCollector\EventDataCollector;
+use PHPUnit_Framework_TestCase;
+use Psr\Log\LogLevel;
+
+/**
+ * AbstractReportTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class AbstractReportTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests if constructing a new AbstractReport sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+                ->getMock();
+
+        $report = $this->getMockBuilder('Accompli\Report\AbstractReport')
+                ->setConstructorArgs(array($eventDataCollectorMock, array($eventDataCollectorMock)))
+                ->getMockForAbstractClass();
+
+        $this->assertAttributeSame($eventDataCollectorMock, 'eventDataCollector', $report);
+        $this->assertAttributeSame(array($eventDataCollectorMock), 'dataCollectors', $report);
+    }
+
+    /**
+     * Tests if AbstractReport::generate generates the expected output.
+     *
+     * @dataProvider provideTestGenerate
+     *
+     * @param EventDataCollector $eventDataCollectorMock
+     * @param string             $beforeAfterTitleBlockLine
+     * @param string             $titleBlockLine
+     */
+    public function testGenerate(EventDataCollector $eventDataCollectorMock, $beforeAfterTitleBlockLine, $titleBlockLine)
+    {
+        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+                ->getMock();
+        $dataCollectorMock->expects($this->once())
+                ->method('getData')
+                ->willReturn(array('Test item' => 'Test item data'));
+
+        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+                ->getMock();
+        $outputFormatterMock->expects($this->any())
+                ->method('format')
+                ->willReturnArgument(0);
+
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+                ->getMock();
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+        $outputMock->expects($this->exactly(9))
+                ->method('writeln')
+                ->withConsecutive(
+                    array($this->equalTo('')),
+                    array($this->stringStartsWith($beforeAfterTitleBlockLine)),
+                    array($this->stringStartsWith($titleBlockLine)),
+                    array($this->stringStartsWith($beforeAfterTitleBlockLine)),
+                    array($this->equalTo('')),
+                    array($this->equalTo(' ----------- ---------------- ')),
+                    array($this->equalTo('')),
+                    array($this->equalTo(' ----------- ---------------- ')),
+                    array($this->equalTo(''))
+                );
+        $outputMock->expects($this->exactly(5))
+                ->method('write')
+                ->withConsecutive(
+                    array($this->equalTo(' ')),
+                    array($this->equalTo(' Test item ')),
+                    array($this->equalTo(' ')),
+                    array($this->equalTo(' Test item data ')),
+                    array($this->equalTo(' '))
+                );
+
+        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+                ->getMock();
+        $loggerMock->expects($this->once())
+                ->method('getOutput')
+                ->willReturn($outputMock);
+
+        $report = $this->getMockBuilder('Accompli\Report\AbstractReport')
+                ->setConstructorArgs(array($eventDataCollectorMock, array($eventDataCollectorMock, $dataCollectorMock)))
+                ->getMockForAbstractClass();
+
+        $report->generate($loggerMock);
+    }
+
+    /**
+     * Returns an array with the various (test) scenarios for AbstractReport::generate.
+     *
+     * @return array
+     */
+    public function provideTestGenerate()
+    {
+        $provide = array();
+
+        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+                ->getMock();
+        $eventDataCollectorMock->expects($this->once())
+                ->method('getData')
+                ->willReturn(array());
+
+        $provide[] = array($eventDataCollectorMock, '<fg=black;bg=green>', '<fg=black;bg=green> [OK]');
+
+        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+                ->getMock();
+        $eventDataCollectorMock->expects($this->once())
+                ->method('hasCountedFailedEvents')
+                ->willReturn(true);
+        $eventDataCollectorMock->expects($this->once())
+                ->method('getData')
+                ->willReturn(array());
+
+        $provide[] = array($eventDataCollectorMock, '<fg=white;bg=red>', '<fg=white;bg=red> [FAILURE]');
+
+        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+                ->getMock();
+        $eventDataCollectorMock->expects($this->once())
+                ->method('hasCountedLogLevel')
+                ->with(LogLevel::EMERGENCY)
+                ->willReturn(true);
+        $eventDataCollectorMock->expects($this->once())
+                ->method('getData')
+                ->willReturn(array());
+
+        $provide[] = array($eventDataCollectorMock, '<fg=black;bg=yellow>', '<fg=black;bg=yellow> [OK, but with errors]');
+
+        return $provide;
+    }
+}

--- a/tests/Task/ComposerInstallTaskTest.php
+++ b/tests/Task/ComposerInstallTaskTest.php
@@ -80,7 +80,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnPrepareWorkspaceInstallComposerFailsInstallingComposer()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(1))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())->method('isFile')->willReturn(false);
@@ -101,6 +101,8 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
 
         $event = new WorkspaceEvent($hostMock);
         $event->setWorkspace($workspaceMock);
+
+        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed installing the Composer binary.');
 
         $task = new ComposerInstallTask();
         $task->onPrepareWorkspaceInstallComposer($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
@@ -172,9 +174,6 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests if ComposerInstallTask::onPrepareWorkspaceInstallComposer throws a RuntimeException when no Workspace instance is available.
-     *
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage The workspace of the host has not been created.
      */
     public function testOnPrepareWorkspaceInstallComposerThrowsRuntimeExceptionWhenWorkspaceInstanceNotAvailable()
     {
@@ -189,6 +188,8 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
         $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
+
+        $this->setExpectedException('Accompli\Exception\TaskRuntimeException', 'The workspace of the host has not been created.');
 
         $task = new ComposerInstallTask();
         $task->onPrepareWorkspaceInstallComposer($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
@@ -286,7 +287,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
     public function testOnInstallReleaseExecuteComposerInstallFails()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(1))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->once())
@@ -312,6 +313,8 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
         $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
 
         $event = new InstallReleaseEvent($releaseMock);
+
+        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed installing Composer dependencies.');
 
         $task = new ComposerInstallTask();
         $task->onInstallReleaseExecuteComposerInstall($event, AccompliEvents::INSTALL_RELEASE, $eventDispatcherMock);

--- a/tests/Task/ExecuteCommandTaskTest.php
+++ b/tests/Task/ExecuteCommandTaskTest.php
@@ -121,7 +121,7 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
     public function testOnEventFailure()
     {
         $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(1))->method('dispatch');
 
         $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
         $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');
@@ -151,6 +151,8 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
                 ->willReturn($workspaceMock);
 
         $event = new ReleaseEvent($releaseMock);
+
+        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed executing command "echo".');
 
         $task = new ExecuteCommandTask(array(AccompliEvents::INSTALL_RELEASE), 'echo', array('test'));
         $task->onEvent($event, AccompliEvents::INSTALL_RELEASE, $eventDispatcherMock);

--- a/tests/Task/RepositoryCheckoutTaskTest.php
+++ b/tests/Task/RepositoryCheckoutTaskTest.php
@@ -160,6 +160,8 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
         $event = new PrepareReleaseEvent($workspaceMock, '0.1.0');
         $event->setRelease($releaseMock);
 
+        $this->setExpectedException('Accompli\Exception\TaskRuntimeException', 'Failed to checkout version "0.1.0" from repository "https://github.com/accompli/accompli.git".');
+
         $task = new RepositoryCheckoutTask('https://github.com/accompli/accompli.git');
         $task->onPrepareReleaseCheckoutRepository($event, AccompliEvents::PREPARE_RELEASE, $eventDispatcherMock);
     }


### PR DESCRIPTION
Improves existing output by outputting the host tasks are being executed for. 

This PR also adds the first version of data collectors that gather information about task execution and are able to output information after execution in through a `InstallReport` or `DeployReport`. The data collectors provide information based on the requested verbosity level.

Closes #130, closes #132 and closes #137.
