### PR TITLE
Removed useless config entries

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,13 +1,7 @@
 preset: symfony
 
-linting: true
-
 enabled:
   - ordered_use
 
 disabled:
   - unneeded_control_parentheses
-
-finder:
-  not-name:
-    - "*.phar"


### PR DESCRIPTION
Linting is enabled by default, and we only include `*.php` files by default, so your `not-name` entry does nothing.
