### PR TITLE
Remove PHP 5.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^5.5 || ^7.0",
         "accompli/chrono": "^0.3.0",
         "composer/semver": "^1.2",
         "justinrainbow/json-schema": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "80e5cb51d61238757b6e332d6a123398",
-    "content-hash": "3714c543441af6d40bde92fbf4608c88",
+    "hash": "016d80a25b92a6170da190467df38488",
+    "content-hash": "5263b898b6bc37695fcf5f407a9519e1",
     "packages": [
         {
             "name": "accompli/chrono",
@@ -447,16 +447,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "24f155da1ff180df8e15e34a8f6e2f8a0eadefa8"
+                "reference": "048dc47e07f92333203c3b7045868bbc864fc40e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/24f155da1ff180df8e15e34a8f6e2f8a0eadefa8",
-                "reference": "24f155da1ff180df8e15e34a8f6e2f8a0eadefa8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/048dc47e07f92333203c3b7045868bbc864fc40e",
+                "reference": "048dc47e07f92333203c3b7045868bbc864fc40e",
                 "shasum": ""
             },
             "require": {
@@ -469,7 +469,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -496,20 +496,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-20 18:53:54"
+            "time": "2016-05-20 11:48:17"
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "34a214710e0714b6efcf40ba3cd1e31373a97820"
+                "reference": "f62db5b8afec27073a4609b8c84b1f9936652259"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/34a214710e0714b6efcf40ba3cd1e31373a97820",
-                "reference": "34a214710e0714b6efcf40ba3cd1e31373a97820",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f62db5b8afec27073a4609b8c84b1f9936652259",
+                "reference": "f62db5b8afec27073a4609b8c84b1f9936652259",
                 "shasum": ""
             },
             "require": {
@@ -529,7 +529,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -556,20 +556,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-28 09:48:42"
+            "time": "2016-05-30 06:58:39"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b2f4d40a6ed0f6ace59aa3c88d08a94eb9aef811"
+                "reference": "383110341e8f47ae972da3a29503b099831549e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b2f4d40a6ed0f6ace59aa3c88d08a94eb9aef811",
-                "reference": "b2f4d40a6ed0f6ace59aa3c88d08a94eb9aef811",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/383110341e8f47ae972da3a29503b099831549e1",
+                "reference": "383110341e8f47ae972da3a29503b099831549e1",
                 "shasum": ""
             },
             "require": {
@@ -589,7 +589,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -616,20 +616,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-09 18:14:44"
+            "time": "2016-05-24 10:06:56"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "807dde98589f9b2b00624dca326740380d78dbbc"
+                "reference": "0343b2cedd0edb26cdc791212a8eb645c406018b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/807dde98589f9b2b00624dca326740380d78dbbc",
-                "reference": "807dde98589f9b2b00624dca326740380d78dbbc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0343b2cedd0edb26cdc791212a8eb645c406018b",
+                "reference": "0343b2cedd0edb26cdc791212a8eb645c406018b",
                 "shasum": ""
             },
             "require": {
@@ -649,7 +649,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -676,20 +676,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-05 06:56:13"
+            "time": "2016-04-12 18:27:47"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "74fec3511b62cb934b64bce1d96f06fffa4beafd"
+                "reference": "5751e80d6f94b7c018f338a4a7be0b700d6f3058"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/74fec3511b62cb934b64bce1d96f06fffa4beafd",
-                "reference": "74fec3511b62cb934b64bce1d96f06fffa4beafd",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5751e80d6f94b7c018f338a4a7be0b700d6f3058",
+                "reference": "5751e80d6f94b7c018f338a4a7be0b700d6f3058",
                 "shasum": ""
             },
             "require": {
@@ -698,7 +698,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -725,7 +725,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:09:53"
+            "time": "2016-04-12 18:27:47"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -788,16 +788,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "53f9407c0bb1c5a79127db8f7bfe12f0f6f3dcdb"
+                "reference": "1574f3451b40fa9bbae518ef71d19a56f409cac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/53f9407c0bb1c5a79127db8f7bfe12f0f6f3dcdb",
-                "reference": "53f9407c0bb1c5a79127db8f7bfe12f0f6f3dcdb",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1574f3451b40fa9bbae518ef71d19a56f409cac0",
+                "reference": "1574f3451b40fa9bbae518ef71d19a56f409cac0",
                 "shasum": ""
             },
             "require": {
@@ -806,7 +806,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -833,20 +833,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-14 15:30:28"
+            "time": "2016-04-12 19:11:33"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96"
+                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0047c8366744a16de7516622c5b7355336afae96",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
+                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
                 "shasum": ""
             },
             "require": {
@@ -855,7 +855,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -882,7 +882,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "time": "2016-05-26 21:46:24"
         }
     ],
     "packages-dev": [
@@ -1945,16 +1945,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "6015187088421e9499d8f8316bdb396f8b806c06"
+                "reference": "4670f122fa32a4900003a6802f6b8575f3f0b17e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6015187088421e9499d8f8316bdb396f8b806c06",
-                "reference": "6015187088421e9499d8f8316bdb396f8b806c06",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4670f122fa32a4900003a6802f6b8575f3f0b17e",
+                "reference": "4670f122fa32a4900003a6802f6b8575f3f0b17e",
                 "shasum": ""
             },
             "require": {
@@ -1963,7 +1963,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1990,7 +1990,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "time": "2016-03-04 07:56:56"
         }
     ],
     "aliases": [],
@@ -1999,7 +1999,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.4 || ^7.0"
+        "php": "^5.5 || ^7.0"
     },
     "platform-dev": []
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -197,7 +197,7 @@ class Configuration implements ConfigurationInterface
     {
         if (empty($this->hosts) && isset($this->configuration['hosts'])) {
             foreach ($this->configuration['hosts'] as $host) {
-                $this->hosts[] = ObjectFactory::getInstance()->newInstance('Accompli\Deployment\Host', $host);
+                $this->hosts[] = ObjectFactory::getInstance()->newInstance(Host::class, $host);
             }
         }
 

--- a/src/Deployment/Connection/ConnectionManager.php
+++ b/src/Deployment/Connection/ConnectionManager.php
@@ -32,7 +32,7 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     public function registerConnectionAdapter($connectionType, $connectionAdapterClass)
     {
-        if (class_exists($connectionAdapterClass) && in_array('Accompli\Deployment\Connection\ConnectionAdapterInterface', class_implements($connectionAdapterClass))) {
+        if (class_exists($connectionAdapterClass) && in_array(ConnectionAdapterInterface::class, class_implements($connectionAdapterClass))) {
             $this->connectionAdapters[$connectionType] = $connectionAdapterClass;
         }
     }

--- a/tests/AccompliEventsTest.php
+++ b/tests/AccompliEventsTest.php
@@ -18,7 +18,7 @@ class AccompliEventsTest extends PHPUnit_Framework_TestCase
      */
     public function testGetEventNames()
     {
-        $reflectionClass = new ReflectionClass('Accompli\\AccompliEvents');
+        $reflectionClass = new ReflectionClass(AccompliEvents::class);
 
         $this->assertSame(array_values($reflectionClass->getConstants()), AccompliEvents::getEventNames());
     }

--- a/tests/AccompliTest.php
+++ b/tests/AccompliTest.php
@@ -3,10 +3,18 @@
 namespace Accompli\Test;
 
 use Accompli\Accompli;
+use Accompli\Configuration\ConfigurationInterface;
+use Accompli\Deployment\Connection\ConnectionManagerInterface;
 use Accompli\Deployment\Host;
+use Accompli\Deployment\Strategy\DeploymentStrategyInterface;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use Nijens\ProtocolStream\StreamManager;
 use PHPUnit_Framework_TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * AccompliTest.
@@ -27,7 +35,8 @@ class AccompliTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $outputInterfaceMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
 
         $this->serviceContainerParameters = array(
             'configuration.file' => __DIR__.'/Resources/accompli-with-mock-listeners.json',
@@ -71,7 +80,7 @@ class AccompliTest extends PHPUnit_Framework_TestCase
         $accompli = new Accompli(new ParameterBag($this->serviceContainerParameters));
         $accompli->initializeContainer();
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\ContainerInterface', $accompli->getContainer());
+        $this->assertInstanceOf(ContainerInterface::class, $accompli->getContainer());
     }
 
     /**
@@ -102,7 +111,7 @@ class AccompliTest extends PHPUnit_Framework_TestCase
         $accompli = new Accompli(new ParameterBag($this->serviceContainerParameters));
         $accompli->initializeContainer();
 
-        $this->assertInstanceOf('Accompli\Configuration\ConfigurationInterface', $accompli->getConfiguration());
+        $this->assertInstanceOf(ConfigurationInterface::class, $accompli->getConfiguration());
     }
 
     /**
@@ -128,7 +137,8 @@ class AccompliTest extends PHPUnit_Framework_TestCase
      */
     public function testInstall()
     {
-        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder(DeploymentStrategyInterface::class)
+                ->getMock();
         $deploymentStrategyMock->expects($this->once())
                 ->method('install')
                 ->with(
@@ -137,12 +147,13 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->once())
                 ->method('dispatch');
 
-        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)
+                ->getMock();
         $containerMock->expects($this->exactly(2))
                 ->method('get')
                 ->withConsecutive(
@@ -154,9 +165,10 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                     $eventDispatcherMock
                 );
 
-        $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
+        $parameterBagMock = $this->getMockBuilder(ParameterBagInterface::class)
+                ->getMock();
 
-        $accompli = $this->getMockBuilder('Accompli\Accompli')
+        $accompli = $this->getMockBuilder(Accompli::class)
                 ->setConstructorArgs(array($parameterBagMock))
                 ->setMethods(array('getContainer'))
                 ->getMock();
@@ -172,7 +184,8 @@ class AccompliTest extends PHPUnit_Framework_TestCase
      */
     public function testDeploy()
     {
-        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder(DeploymentStrategyInterface::class)
+                ->getMock();
         $deploymentStrategyMock->expects($this->once())
                 ->method('deploy')
                 ->with(
@@ -181,12 +194,13 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->once())
                 ->method('dispatch');
 
-        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)
+                ->getMock();
         $containerMock->expects($this->exactly(2))
                 ->method('get')
                 ->withConsecutive(
@@ -198,9 +212,10 @@ class AccompliTest extends PHPUnit_Framework_TestCase
                     $eventDispatcherMock
                 );
 
-        $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
+        $parameterBagMock = $this->getMockBuilder(ParameterBagInterface::class)
+                ->getMock();
 
-        $accompli = $this->getMockBuilder('Accompli\Accompli')
+        $accompli = $this->getMockBuilder(Accompli::class)
                 ->setConstructorArgs(array($parameterBagMock))
                 ->setMethods(array('getContainer'))
                 ->getMock();
@@ -219,10 +234,10 @@ class AccompliTest extends PHPUnit_Framework_TestCase
     public function provideServiceContainerServices()
     {
         return array(
-            array('configuration', 'Accompli\Configuration\ConfigurationInterface'),
-            array('connection_manager', 'Accompli\Deployment\Connection\ConnectionManagerInterface'),
-            array('event_dispatcher', 'Accompli\EventDispatcher\EventDispatcherInterface'),
-            array('logger', 'Psr\Log\LoggerInterface'),
+            array('configuration', ConfigurationInterface::class),
+            array('connection_manager', ConnectionManagerInterface::class),
+            array('event_dispatcher', EventDispatcherInterface::class),
+            array('logger', LoggerInterface::class),
         );
     }
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -122,7 +122,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $configuration->getHosts());
         $this->assertNotEmpty($configuration->getHosts());
-        $this->assertInstanceOf('Accompli\Deployment\Host', current($configuration->getHosts()));
+        $this->assertInstanceOf(Host::class, current($configuration->getHosts()));
     }
 
     /**
@@ -172,7 +172,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $configuration->getHostsByStage(Host::STAGE_TEST));
         $this->assertNotEmpty($configuration->getHostsByStage(Host::STAGE_TEST));
-        $this->assertInstanceOf('Accompli\Deployment\Host', current($configuration->getHostsByStage(Host::STAGE_TEST)));
+        $this->assertInstanceOf(Host::class, current($configuration->getHostsByStage(Host::STAGE_TEST)));
     }
 
     /**

--- a/tests/Console/Helper/TitleBlockTest.php
+++ b/tests/Console/Helper/TitleBlockTest.php
@@ -5,6 +5,7 @@ namespace Accompli\Test\Console\Helper;
 use Accompli\Console\Helper\TitleBlock;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * TitleBlockTest.
@@ -18,7 +19,7 @@ class TitleBlockTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
 
         $titleBlock = new TitleBlock($outputMock, 'Test message', TitleBlock::STYLE_SUCCESS);
@@ -41,7 +42,7 @@ class TitleBlockTest extends PHPUnit_Framework_TestCase
     {
         $outputFormatter = new OutputFormatter();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->exactly(3))
                 ->method('getFormatter')

--- a/tests/Console/Helper/TitleTest.php
+++ b/tests/Console/Helper/TitleTest.php
@@ -5,6 +5,7 @@ namespace Accompli\Test\Console\Helper;
 use Accompli\Console\Helper\Title;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * TitleTest.
@@ -18,7 +19,7 @@ class TitleTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
 
         $title = new Title($outputMock, 'Test message');
@@ -34,7 +35,7 @@ class TitleTest extends PHPUnit_Framework_TestCase
     {
         $outputFormatter = new OutputFormatter();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getFormatter')

--- a/tests/Console/Logger/ConsoleLoggerTest.php
+++ b/tests/Console/Logger/ConsoleLoggerTest.php
@@ -8,6 +8,8 @@ use PHPUnit_Framework_TestCase;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -22,7 +24,8 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
 
         $logger = new ConsoleLogger($outputMock);
 
@@ -34,13 +37,16 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructUpdatesTaskActionStatusMapBasedOnOperatingSystem()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
 
-        $logger = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLogger')
+        $logger = $this->getMockBuilder(ConsoleLogger::class)
                 ->disableOriginalConstructor()
                 ->setMethods(array('getOperatingSystemName'))
                 ->getMock();
-        $logger->expects($this->once())->method('getOperatingSystemName')->willReturn('WIN');
+        $logger->expects($this->once())
+                ->method('getOperatingSystemName')
+                ->willReturn('WIN');
         $logger->__construct($outputMock);
 
         $expectedValue = array(
@@ -57,7 +63,7 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetVerbosity()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getVerbosity')
@@ -73,7 +79,7 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetOutput()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
 
         $logger = new ConsoleLogger($outputMock);
@@ -86,10 +92,10 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetOutputReturnsErrorOutput()
     {
-        $errorOutputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $errorOutputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutputInterface')
+        $outputMock = $this->getMockBuilder(ConsoleOutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getErrorOutput')
@@ -108,7 +114,8 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogWithInvalidLogLevelThrowsInvalidArgumentException()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
 
         $logger = new ConsoleLogger($outputMock);
         $logger->log('invalid', 'message');
@@ -125,11 +132,17 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogWritesLogLevelsToOutputBasedOnVerbosity($logLevel, $verbosityLevel, $output)
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->once())->method('getVerbosity')->willReturn($verbosityLevel);
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn($verbosityLevel);
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
 
         $callOccurence = $this->never();
         if ($output === true) {
@@ -151,17 +164,29 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogWritesLogLevelsToErrorOutput($logLevel)
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $errorOutputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $errorOutputMock->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $errorOutputMock->expects($this->once())->method('writeln');
+        $errorOutputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $errorOutputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $errorOutputMock->expects($this->once())
+                ->method('writeln');
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutputInterface')->getMock();
-        $outputMock->expects($this->once())->method('getErrorOutput')->willReturn($errorOutputMock);
-        $outputMock->expects($this->never())->method('getVerbosity');
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
-        $outputMock->expects($this->never())->method('writeln');
+        $outputMock = $this->getMockBuilder(ConsoleOutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getErrorOutput')
+                ->willReturn($errorOutputMock);
+        $outputMock->expects($this->never())
+                ->method('getVerbosity');
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+        $outputMock->expects($this->never())
+                ->method('writeln');
 
         $logger = new ConsoleLogger($outputMock);
         $logger->log($logLevel, 'message');
@@ -172,12 +197,20 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogContextReplacements()
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
-        $outputMock->expects($this->once())->method('writeln')->with($this->equalTo('  <notice>Message to Bob</notice>'));
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
+        $outputMock->expects($this->once())
+                ->method('writeln')
+                ->with($this->equalTo('  <notice>Message to Bob</notice>'));
 
         $logger = new ConsoleLogger($outputMock);
         $logger->log(LogLevel::NOTICE, 'Message to {user}', array('user' => 'Bob'));
@@ -188,11 +221,17 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogMessageSections()
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
         $outputMock->expects($this->once())
                 ->method('writeln')
                 ->with($this->equalTo('[<event-name>accompli.test                     </event-name>][<event-task-name>TestTask                 </event-task-name>]  <notice>message</notice>'));
@@ -206,11 +245,17 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogMessageSectionsWithSameContextIndented()
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->exactly(2))->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->exactly(2))
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
         $outputMock->expects($this->exactly(2))
                 ->method('writeln')
                 ->withConsecutive(
@@ -233,11 +278,17 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogTaskActionStatus($actionStatus, $expectedLogMessage)
     {
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')->getMock();
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
+                ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $outputMock->expects($this->any())->method('getFormatter')->willReturn($outputFormatterMock);
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->once())
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $outputMock->expects($this->any())
+                ->method('getFormatter')
+                ->willReturn($outputFormatterMock);
         $outputMock->expects($this->once())
                 ->method('writeln')
                 ->with($this->equalTo($expectedLogMessage));
@@ -251,9 +302,14 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
      */
     public function testLogReplaceLine()
     {
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $outputMock->expects($this->exactly(2))->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
-        $outputMock->expects($this->exactly(5))->method('isDecorated')->willReturn(true);
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
+                ->getMock();
+        $outputMock->expects($this->exactly(2))
+                ->method('getVerbosity')
+                ->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $outputMock->expects($this->exactly(5))
+                ->method('isDecorated')
+                ->willReturn(true);
         $outputMock->expects($this->exactly(3))
                 ->method('getFormatter')
                 ->willReturn(new OutputFormatter(true));
@@ -267,11 +323,13 @@ class ConsoleLoggerTest extends PHPUnit_Framework_TestCase
                     array($this->equalTo(" \e[1D <notice>message</notice>"))
                 );
 
-        $logger = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLogger')
+        $logger = $this->getMockBuilder(ConsoleLogger::class)
                 ->setConstructorArgs(array($outputMock))
                 ->setMethods(array('getTerminalWidth'))
                 ->getMock();
-        $logger->expects($this->exactly(2))->method('getTerminalWidth')->willReturn(150);
+        $logger->expects($this->exactly(2))
+                ->method('getTerminalWidth')
+                ->willReturn(150);
 
         $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask'));
         $logger->log(LogLevel::NOTICE, 'message', array('event.name' => 'accompli.test', 'event.task.name' => 'TestTask', 'output.resetLine' => true));

--- a/tests/DataCollector/EventDataCollectorTest.php
+++ b/tests/DataCollector/EventDataCollectorTest.php
@@ -4,6 +4,8 @@ namespace Accompli\Test\DataCollector;
 
 use Accompli\AccompliEvents;
 use Accompli\DataCollector\EventDataCollector;
+use Accompli\EventDispatcher\Event\FailedEvent;
+use Accompli\EventDispatcher\Event\LogEvent;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LogLevel;
 
@@ -19,7 +21,7 @@ class EventDataCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testCollectLogEvent()
     {
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+        $eventMock = $this->getMockBuilder(LogEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->once())
@@ -48,7 +50,7 @@ class EventDataCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testCollectFailedEvent()
     {
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+        $eventMock = $this->getMockBuilder(FailedEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -81,7 +83,7 @@ class EventDataCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testHasCountedLogLevelReturnsTrueWhenCountedLogLevels()
     {
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+        $eventMock = $this->getMockBuilder(LogEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->once())
@@ -109,7 +111,7 @@ class EventDataCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testHasCountedFailedEventsReturnsTrueWhenCountedFailedEvents()
     {
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+        $eventMock = $this->getMockBuilder(FailedEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/DependencyInjection/AwarenessCompilerPassTest.php
+++ b/tests/DependencyInjection/AwarenessCompilerPassTest.php
@@ -2,7 +2,9 @@
 
 namespace Accompli\Test\DependencyInjection;
 
+use Accompli\Configuration\ConfigurationInterface;
 use Accompli\DependencyInjection\AwarenessCompilerPass;
+use Accompli\DependencyInjection\ConfigurationAwareInterface;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -20,8 +22,10 @@ class AwarenessCompilerPassTest extends PHPUnit_Framework_TestCase
      */
     public function testProcess()
     {
-        $configurationAwarenessMock = $this->getMockBuilder('Accompli\DependencyInjection\ConfigurationAwareInterface')->getMock();
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationAwarenessMock = $this->getMockBuilder(ConfigurationAwareInterface::class)
+                ->getMock();
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
 
         $container = new ContainerBuilder();
         $container->set('configuration', $configurationMock);

--- a/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
+++ b/tests/DependencyInjection/ConfigurationServiceRegistrationCompilerPassTest.php
@@ -2,7 +2,11 @@
 
 namespace Accompli\Test\DependencyInjection;
 
+use Accompli\Configuration\ConfigurationInterface;
 use Accompli\DependencyInjection\ConfigurationServiceRegistrationCompilerPass;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Connection\ConnectionManagerInterface;
+use Accompli\Deployment\Strategy\DeploymentStrategyInterface;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -18,10 +22,14 @@ class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework
      */
     public function testProcessAddsConfiguredDeploymentStrategyService()
     {
-        $deploymentStrategyMock = $this->getMockBuilder('Accompli\Deployment\Strategy\DeploymentStrategyInterface')->getMock();
+        $deploymentStrategyMock = $this->getMockBuilder(DeploymentStrategyInterface::class)
+                ->getMock();
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
-        $configurationMock->expects($this->once())->method('getDeploymentStrategyClass')->willReturn(get_class($deploymentStrategyMock));
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getDeploymentStrategyClass')
+                ->willReturn(get_class($deploymentStrategyMock));
 
         $container = new ContainerBuilder();
         $container->set('configuration', $configurationMock);
@@ -37,13 +45,18 @@ class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework
      */
     public function testProcessAddsConfiguredConnectionClassesToConnectionManager()
     {
-        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionMockClass = get_class($connectionMock);
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
-        $configurationMock->expects($this->once())->method('getDeploymentConnectionClasses')->willReturn(array('local' => $connectionMockClass));
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getDeploymentConnectionClasses')
+                ->willReturn(array('local' => $connectionMockClass));
 
-        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManagerInterface')->getMock();
+        $connectionManagerMock = $this->getMockBuilder(ConnectionManagerInterface::class)
+                ->getMock();
         $connectionManagerMock->expects($this->once())
                 ->method('registerConnectionAdapter')
                 ->with($this->equalTo('local'), $this->equalTo($connectionMockClass));
@@ -61,8 +74,10 @@ class ConfigurationServiceRegistrationCompilerPassTest extends PHPUnit_Framework
      */
     public function testProcessDoesNothingWithoutRegisteredConfigurationService()
     {
-        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManagerInterface')->getMock();
-        $connectionManagerMock->expects($this->never())->method('registerConnectionAdapter');
+        $connectionManagerMock = $this->getMockBuilder(ConnectionManagerInterface::class)
+                ->getMock();
+        $connectionManagerMock->expects($this->never())
+                ->method('registerConnectionAdapter');
 
         $container = new ContainerBuilder();
         $container->set('connection_manager', $connectionManagerMock);

--- a/tests/Deployment/Connection/ConnectedConnectionAdapterTestCase.php
+++ b/tests/Deployment/Connection/ConnectedConnectionAdapterTestCase.php
@@ -2,6 +2,8 @@
 
 namespace Accompli\Test\Deployment\Connection;
 
+use Accompli\Chrono\Process\ProcessExecutionResult;
+
 /**
  * ConnectedConnectionAdapterTestCase.
  *
@@ -81,7 +83,7 @@ abstract class ConnectedConnectionAdapterTestCase extends ConnectionAdapterTestC
     public function testExecuteCommandReturnsFalseWhenNotConnected()
     {
         $result = $this->connectionAdapter->executeCommand('echo test');
-        $this->assertInstanceOf('Accompli\Chrono\Process\ProcessExecutionResult', $result);
+        $this->assertInstanceOf(ProcessExecutionResult::class, $result);
         $this->assertSame(126, $result->getExitCode());
         $this->assertSame('', $result->getOutput());
         $this->assertSame("Connection adapter not connected.\n", $result->getErrorOutput());

--- a/tests/Deployment/Connection/ConnectionAdapterProcessExecutorTest.php
+++ b/tests/Deployment/Connection/ConnectionAdapterProcessExecutorTest.php
@@ -3,6 +3,7 @@
 namespace Accompli\Test\Deployment\Connection;
 
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Deployment\Connection\ConnectionAdapterProcessExecutor;
 use PHPUnit_Framework_TestCase;
 
@@ -18,7 +19,8 @@ class ConnectionAdapterProcessExecutorTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $processExecutor = new ConnectionAdapterProcessExecutor($connectionAdapterMock);
 
@@ -32,8 +34,11 @@ class ConnectionAdapterProcessExecutorTest extends PHPUnit_Framework_TestCase
      */
     public function testIsDirectory()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isDirectory')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isDirectory')
+                ->willReturn(true);
 
         $processExecutor = new ConnectionAdapterProcessExecutor($connectionAdapterMock);
 
@@ -47,12 +52,15 @@ class ConnectionAdapterProcessExecutorTest extends PHPUnit_Framework_TestCase
      */
     public function testExecute()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('executeCommand')->willReturn(new ProcessExecutionResult(0, '', ''));
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('executeCommand')
+                ->willReturn(new ProcessExecutionResult(0, '', ''));
 
         $processExecutor = new ConnectionAdapterProcessExecutor($connectionAdapterMock);
 
-        $this->assertInstanceOf('Accompli\Chrono\Process\ProcessExecutionResult', $processExecutor->execute('echo test'));
+        $this->assertInstanceOf(ProcessExecutionResult::class, $processExecutor->execute('echo test'));
     }
 
     /**
@@ -62,15 +70,16 @@ class ConnectionAdapterProcessExecutorTest extends PHPUnit_Framework_TestCase
      */
     public function testExecuteWithWorkingDirectory()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('getWorkingDirectory')
                 ->willReturn('/previous/directory');
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('changeWorkingDirectory')
                 ->withConsecutive(
-                        array('/test/path'),
-                        array('/previous/directory')
+                    array('/test/path'),
+                    array('/previous/directory')
                 )
                 ->willReturn(true);
         $connectionAdapterMock->expects($this->once())
@@ -79,6 +88,6 @@ class ConnectionAdapterProcessExecutorTest extends PHPUnit_Framework_TestCase
 
         $processExecutor = new ConnectionAdapterProcessExecutor($connectionAdapterMock);
 
-        $this->assertInstanceOf('Accompli\Chrono\Process\ProcessExecutionResult', $processExecutor->execute('echo test', '/test/path'));
+        $this->assertInstanceOf(ProcessExecutionResult::class, $processExecutor->execute('echo test', '/test/path'));
     }
 }

--- a/tests/Deployment/Connection/ConnectionAdapterTestCase.php
+++ b/tests/Deployment/Connection/ConnectionAdapterTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\Deployment\Connection;
 
+use Accompli\Chrono\Process\ProcessExecutionResult;
 use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Test\WorkspaceUtility;
 use PHPUnit_Framework_TestCase;
@@ -210,7 +211,7 @@ abstract class ConnectionAdapterTestCase extends PHPUnit_Framework_TestCase
         $this->connectionAdapter->connect();
 
         $result = $this->connectionAdapter->executeCommand('echo test');
-        $this->assertInstanceOf('Accompli\Chrono\Process\ProcessExecutionResult', $result);
+        $this->assertInstanceOf(ProcessExecutionResult::class, $result);
         $this->assertSame(0, $result->getExitCode());
         $this->assertSame('test'.PHP_EOL, $result->getOutput());
         $this->assertSame('', $result->getErrorOutput());
@@ -226,7 +227,7 @@ abstract class ConnectionAdapterTestCase extends PHPUnit_Framework_TestCase
         $this->connectionAdapter->connect();
 
         $result = $this->connectionAdapter->executeCommand('echo', array('test'));
-        $this->assertInstanceOf('Accompli\Chrono\Process\ProcessExecutionResult', $result);
+        $this->assertInstanceOf(ProcessExecutionResult::class, $result);
         $this->assertSame(0, $result->getExitCode());
         $this->assertSame('test'.PHP_EOL, $result->getOutput());
         $this->assertSame('', $result->getErrorOutput());

--- a/tests/Deployment/Connection/ConnectionManagerTest.php
+++ b/tests/Deployment/Connection/ConnectionManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\Deployment\Connection;
 
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Deployment\Connection\ConnectionManager;
 use Accompli\Deployment\Host;
 use Accompli\EventDispatcher\Event\HostEvent;
@@ -19,7 +20,8 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testRegisterConnectionTypeAddsValidConnectionAdapter()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $connectionManager = new ConnectionManager();
         $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
@@ -32,7 +34,8 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testRegisterConnectionTypeDoesNotAddInvalidConnectionAdapter()
     {
-        $connectionManagerMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionManager')->getMock();
+        $connectionManagerMock = $this->getMockBuilder(ConnectionManager::class)
+                ->getMock();
 
         $connectionManager = new ConnectionManager();
         $connectionManager->registerConnectionAdapter('test', get_class($connectionManagerMock));
@@ -68,14 +71,15 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetConnectionAdapterReturnsConnectionAdapter()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $host = new Host('test', 'test', 'example.org', '');
 
         $connectionManager = new ConnectionManager();
         $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
 
-        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $connectionManager->getConnectionAdapter($host));
+        $this->assertInstanceOf(ConnectionAdapterInterface::class, $connectionManager->getConnectionAdapter($host));
     }
 
     /**
@@ -85,7 +89,8 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetConnectionAdapterAlwaysReturnsTheSameInstance()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $host = new Host('test', 'test', 'example.org', '');
 
@@ -104,7 +109,8 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testGetConnectionAdapterDoesNotReturnTheSameInstanceForDifferentHost()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $host = new Host('test', 'test', 'example.org', '');
         $hostTwo = new Host('test', 'test', 'example.org', '', array('connectionOption' => 'connectionOptionValue'));
@@ -122,7 +128,8 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testOnCreateConnection()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $connectionManager = new ConnectionManager();
         $connectionManager->registerConnectionAdapter('test', get_class($connectionAdapterMock));
@@ -132,6 +139,6 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
 
         $connectionManager->onCreateConnection($event);
 
-        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $host->getConnection());
+        $this->assertInstanceOf(ConnectionAdapterInterface::class, $host->getConnection());
     }
 }

--- a/tests/Deployment/HostTest.php
+++ b/tests/Deployment/HostTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\Deployment;
 
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Deployment\Host;
 use PHPUnit_Framework_TestCase;
 use UnexpectedValueException;
@@ -9,7 +10,7 @@ use UnexpectedValueException;
 /**
  * HostTest.
  *
- * @author  Niels Nijens <nijens.niels@gmail.com>
+ * @author Niels Nijens <nijens.niels@gmail.com>
  */
 class HostTest extends PHPUnit_Framework_TestCase
 {
@@ -53,7 +54,8 @@ class HostTest extends PHPUnit_Framework_TestCase
      */
     public function testSetConnectionSetsConnectionAndIsReturnedByGetConnection()
     {
-        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $host = $this->createHostInstance();
         $host->setConnection($connectionMock);
@@ -76,7 +78,8 @@ class HostTest extends PHPUnit_Framework_TestCase
      */
     public function testHasConnectionReturnsTrueWhenConnectionInstanceIsSet()
     {
-        $connectionMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
 
         $host = $this->createHostInstance();
         $host->setConnection($connectionMock);

--- a/tests/Deployment/ReleaseTest.php
+++ b/tests/Deployment/ReleaseTest.php
@@ -3,6 +3,7 @@
 namespace Accompli\Test\Deployment;
 
 use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -27,7 +28,7 @@ class ReleaseTest extends PHPUnit_Framework_TestCase
      */
     public function testSetWorkspace()
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -44,7 +45,7 @@ class ReleaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetWorkspace()
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -73,10 +74,12 @@ class ReleaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetPath()
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getReleasesDirectory')->willReturn('{releases-directory}');
+        $workspaceMock->expects($this->once())
+                ->method('getReleasesDirectory')
+                ->willReturn('{releases-directory}');
 
         $release = new Release('0.1.0');
         $release->setWorkspace($workspaceMock);

--- a/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
+++ b/tests/Deployment/Strategy/RemoteInstallStrategyTest.php
@@ -3,14 +3,21 @@
 namespace Accompli\Test\Deployment\Strategy;
 
 use Accompli\AccompliEvents;
+use Accompli\Configuration\ConfigurationInterface;
+use Accompli\Console\Logger\ConsoleLoggerInterface;
 use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
 use Accompli\Deployment\Strategy\RemoteInstallStrategy;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\FailedEvent;
 use Accompli\EventDispatcher\Event\HostEvent;
 use Accompli\EventDispatcher\Event\InstallReleaseEvent;
 use Accompli\EventDispatcher\Event\PrepareReleaseEvent;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -25,9 +32,13 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallWithoutStageRetrievesHostsFromConfiguration()
     {
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
-        $configurationMock->expects($this->once())->method('getHosts')->willReturn(array());
-        $configurationMock->expects($this->never())->method('getHostsByStage');
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getHosts')
+                ->willReturn(array());
+        $configurationMock->expects($this->never())
+                ->method('getHostsByStage');
 
         $strategy = new RemoteInstallStrategy();
         $strategy->setConfiguration($configurationMock);
@@ -42,8 +53,11 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallWithStageRetrievesHostsByStageFromConfiguration()
     {
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
-        $configurationMock->expects($this->once())->method('getHosts')->willReturn(array());
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
+        $configurationMock->expects($this->once())
+                ->method('getHosts')
+                ->willReturn(array());
         $configurationMock->expects($this->once())
                 ->method('getHostsByStage')
                 ->with($this->equalTo(Host::STAGE_TEST))
@@ -62,17 +76,19 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallDispatchesEventsSuccessfully()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
                 ->getMock();
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
         $configurationMock->expects($this->once())
                 ->method('getHostsByStage')
                 ->with($this->equalTo(Host::STAGE_TEST))
                 ->willReturn(array($hostMock));
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
         $eventDispatcherMock->expects($this->exactly(5))
                 ->method('dispatch')
                 ->withConsecutive(
@@ -104,16 +120,16 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
                 ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getFormatter')
                 ->willReturn($outputFormatterMock);
 
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->once())
                 ->method('getOutput')
@@ -134,16 +150,18 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallDispatchesEventsSuccessfullyForMultipleHosts()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
                 ->getMock();
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
         $configurationMock->expects($this->once())
                 ->method('getHostsByStage')
                 ->willReturn(array($hostMock, $hostMock));
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
         $eventDispatcherMock->expects($this->exactly(10))
                 ->method('dispatch')
                 ->withConsecutive(
@@ -201,16 +219,16 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
                 ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->exactly(2))
                 ->method('getFormatter')
                 ->willReturn($outputFormatterMock);
 
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->exactly(2))
                 ->method('getOutput')
@@ -231,21 +249,22 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallDispatchesEventsSuccessfullyUntillAfterPrepareWorkspaceEvent()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
                 ->getMock();
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
         $configurationMock->expects($this->once())
                 ->method('getHostsByStage')
                 ->with($this->equalTo(Host::STAGE_TEST))
                 ->willReturn(array($hostMock));
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
         $eventDispatcherMock->expects($this->once())
                 ->method('getLastDispatchedEvent')
                 ->willReturn(new Event());
-
         $eventDispatcherMock->expects($this->exactly(4))
                 ->method('dispatch')
                 ->withConsecutive(
@@ -273,16 +292,16 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
                 ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getFormatter')
                 ->willReturn($outputFormatterMock);
 
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->once())
                 ->method('getOutput')
@@ -303,21 +322,22 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function testInstallDispatchesEventsSuccessfullyUntillAfterPrepareReleaseEvent()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->setConstructorArgs(array(Host::STAGE_TEST, 'local', null, __DIR__))
                 ->getMock();
 
-        $configurationMock = $this->getMockBuilder('Accompli\Configuration\ConfigurationInterface')->getMock();
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+                ->getMock();
         $configurationMock->expects($this->once())
                 ->method('getHostsByStage')
                 ->with($this->equalTo(Host::STAGE_TEST))
                 ->willReturn(array($hostMock));
 
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
         $eventDispatcherMock->expects($this->once())
                 ->method('getLastDispatchedEvent')
                 ->willReturn(new Event());
-
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch')
                 ->withConsecutive(
@@ -341,16 +361,16 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
                     )
                 );
 
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
                 ->getMock();
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->once())
                 ->method('getFormatter')
                 ->willReturn($outputFormatterMock);
 
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->once())
                 ->method('getOutput')
@@ -375,7 +395,7 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function provideDispatchCallbackForWorkspaceEvent(Event $event)
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->setConstructorArgs(array($event->getHost()))
                 ->getMock();
 
@@ -395,7 +415,7 @@ class RemoteInstallStrategyTest extends PHPUnit_Framework_TestCase
      */
     public function provideDispatchCallbackForPrepareReleaseEvent(Event $event)
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->setConstructorArgs(array($event->getVersion()))
                 ->getMock();
 

--- a/tests/Deployment/WorkspaceTest.php
+++ b/tests/Deployment/WorkspaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\Deployment;
 
+use Accompli\Deployment\Host;
 use Accompli\Deployment\Release;
 use Accompli\Deployment\Workspace;
 use PHPUnit_Framework_TestCase;
@@ -18,7 +19,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -32,7 +33,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetHost()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -46,7 +47,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testSetReleasesDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -61,7 +62,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testSetDataDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -76,7 +77,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testSetCacheDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -91,7 +92,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testSetOtherDirectories()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -108,7 +109,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetReleasesDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())->method('getPath')->willReturn('{host-base-path}');
@@ -126,7 +127,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetDataDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())->method('getPath')->willReturn('{host-base-path}');
@@ -144,7 +145,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetCacheDirectory()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())->method('getPath')->willReturn('{host-base-path}');
@@ -162,7 +163,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetOtherDirectories()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->exactly(2))->method('getPath')->willReturn('{host-base-path}');
@@ -178,7 +179,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testAddReleaseSetsWorkspaceOnRelease()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -196,7 +197,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetReleasesReturnsEmptyArray()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -213,7 +214,7 @@ class WorkspaceTest extends PHPUnit_Framework_TestCase
      */
     public function testGetReleasesReturnsArrayWithReleaseInstanceAfterAddRelease()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/EventDispatcher/Event/DeployReleaseEventTest.php
+++ b/tests/EventDispatcher/Event/DeployReleaseEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\EventDispatcher\Event;
 
+use Accompli\Deployment\Release;
 use Accompli\EventDispatcher\Event\DeployReleaseEvent;
 use PHPUnit_Framework_TestCase;
 
@@ -17,7 +18,7 @@ class DeployReleaseEventTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -34,11 +35,11 @@ class DeployReleaseEventTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructWithCurrentRelease()
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $currentReleaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $currentReleaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -55,11 +56,11 @@ class DeployReleaseEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetCurrentRelease()
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $currentReleaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $currentReleaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/EventDispatcher/Event/HostEventTest.php
+++ b/tests/EventDispatcher/Event/HostEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\EventDispatcher\Event;
 
+use Accompli\Deployment\Host;
 use Accompli\EventDispatcher\Event\HostEvent;
 use PHPUnit_Framework_TestCase;
 
@@ -17,7 +18,7 @@ class HostEventTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -31,7 +32,7 @@ class HostEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetHost()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/EventDispatcher/Event/LogEventTest.php
+++ b/tests/EventDispatcher/Event/LogEventTest.php
@@ -3,8 +3,10 @@
 namespace Accompli\Test\EventDispatcher\Event;
 
 use Accompli\EventDispatcher\Event\LogEvent;
+use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * LogEventTest.
@@ -18,7 +20,8 @@ class LogEventTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructSetsProperties()
     {
-        $eventSubscriberMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')->getMock();
+        $eventSubscriberMock = $this->getMockBuilder(EventSubscriberInterface::class)
+                ->getMock();
 
         $logEvent = new LogEvent(LogLevel::DEBUG, 'Test', 'accompli.test', $eventSubscriberMock);
 
@@ -31,12 +34,11 @@ class LogEventTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests if constructing a new LogEvent throws an InvalidArgumentException when the log level is invalid.
-     *
-     * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage The provided level "invalid" is not a valid log level.
      */
     public function testConstructThrowInvalidArgumentExceptionWhenLogLevelInvalid()
     {
+        $this->setExpectedException(InvalidArgumentException::class, 'The provided level "invalid" is not a valid log level.');
+
         new LogEvent('invalid', 'Test', 'accompli.test');
     }
 
@@ -75,7 +77,8 @@ class LogEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetEventSubscriberContext()
     {
-        $eventSubscriberMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')->getMock();
+        $eventSubscriberMock = $this->getMockBuilder(EventSubscriberInterface::class)
+                ->getMock();
 
         $logEvent = new LogEvent(LogLevel::DEBUG, 'Test', 'accompli.test', $eventSubscriberMock);
 

--- a/tests/EventDispatcher/Event/ReleaseEventTest.php
+++ b/tests/EventDispatcher/Event/ReleaseEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\EventDispatcher\Event;
 
+use Accompli\Deployment\Release;
 use Accompli\EventDispatcher\Event\ReleaseEvent;
 use PHPUnit_Framework_TestCase;
 
@@ -17,7 +18,7 @@ class ReleaseEventTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -33,7 +34,7 @@ class ReleaseEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetRelease()
     {
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/EventDispatcher/Event/WorkspaceEventTest.php
+++ b/tests/EventDispatcher/Event/WorkspaceEventTest.php
@@ -2,6 +2,8 @@
 
 namespace Accompli\Test\EventDispatcher\Event;
 
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
 use PHPUnit_Framework_TestCase;
 
@@ -17,11 +19,11 @@ class WorkspaceEventTest extends PHPUnit_Framework_TestCase
      */
     public function testSetWorkspace()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -38,11 +40,11 @@ class WorkspaceEventTest extends PHPUnit_Framework_TestCase
      */
     public function testGetCurrentRelease()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/EventDispatcher/EventDispatcherTest.php
+++ b/tests/EventDispatcher/EventDispatcherTest.php
@@ -79,7 +79,7 @@ class EventDispatcherTest extends PHPUnit_Framework_TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->dispatch('test');
 
-        $this->assertInstanceOf('Symfony\Component\EventDispatcher\Event', $eventDispatcher->getLastDispatchedEvent());
+        $this->assertInstanceOf(Event::class, $eventDispatcher->getLastDispatchedEvent());
     }
 
     /**

--- a/tests/EventDispatcher/Subscriber/DataCollectorSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/DataCollectorSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace Accompli\Test\EventDispatcher\Subscriber;
 
+use Accompli\DataCollector\DataCollectorInterface;
 use Accompli\EventDispatcher\Subscriber\DataCollectorSubscriber;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\EventDispatcher\Event;
@@ -38,7 +39,7 @@ class DataCollectorSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testAddDataCollector()
     {
-        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+        $dataCollectorMock = $this->getMockBuilder(DataCollectorInterface::class)
                 ->getMock();
 
         $dataSubscriber = new DataCollectorSubscriber(array());
@@ -54,7 +55,7 @@ class DataCollectorSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testOnEvent()
     {
-        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+        $dataCollectorMock = $this->getMockBuilder(DataCollectorInterface::class)
                 ->getMock();
         $dataCollectorMock->expects($this->once())
                 ->method('collect');

--- a/tests/EventDispatcher/Subscriber/GenerateReportSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/GenerateReportSubscriberTest.php
@@ -3,6 +3,8 @@
 namespace Accompli\Test\EventDispatcher\Subscriber;
 
 use Accompli\AccompliEvents;
+use Accompli\Console\Logger\ConsoleLoggerInterface;
+use Accompli\DataCollector\EventDataCollector;
 use Accompli\EventDispatcher\Subscriber\GenerateReportSubscriber;
 use PHPUnit_Framework_TestCase;
 
@@ -28,10 +30,10 @@ class GenerateReportSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
 
-        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+        $eventDataCollectorMock = $this->getMockBuilder(EventDataCollector::class)
                 ->getMock();
 
         $subscriber = new GenerateReportSubscriber($loggerMock, $eventDataCollectorMock, array());

--- a/tests/EventDispatcher/Subscriber/LogFailureSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/LogFailureSubscriberTest.php
@@ -4,10 +4,12 @@ namespace Accompli\Test\EventDispatcher\Subscriber;
 
 use Accompli\AccompliEvents;
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\EventDispatcher\Event\FailedEvent;
 use Accompli\EventDispatcher\Subscriber\LogFailureSubscriber;
 use Accompli\Exception\TaskCommandExecutionException;
 use Accompli\Task\CreateWorkspaceTask;
 use PHPUnit_Framework_TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 /**
@@ -33,7 +35,8 @@ class LogFailureSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
+                ->getMock();
 
         $logSubscriber = new LogFailureSubscriber($loggerMock);
 
@@ -47,14 +50,14 @@ class LogFailureSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testOnFailedEventLogToLogger()
     {
-        $failedEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+        $failedEventMock = $this->getMockBuilder(FailedEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $failedEventMock->expects($this->once())
                 ->method('getLastEventName')
                 ->willReturn('accompli.test');
 
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->once())
                 ->method('log')
@@ -79,7 +82,7 @@ class LogFailureSubscriberTest extends PHPUnit_Framework_TestCase
 
         $taskCommandExecutionException = new TaskCommandExecutionException('Test exception.', new ProcessExecutionResult(1, 'Command output.', ''), $task);
 
-        $failedEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\FailedEvent')
+        $failedEventMock = $this->getMockBuilder(FailedEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $failedEventMock->expects($this->once())
@@ -89,7 +92,7 @@ class LogFailureSubscriberTest extends PHPUnit_Framework_TestCase
                 ->method('getException')
                 ->willReturn($taskCommandExecutionException);
 
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->exactly(2))
                 ->method('log')

--- a/tests/EventDispatcher/Subscriber/LogSubscriberTest.php
+++ b/tests/EventDispatcher/Subscriber/LogSubscriberTest.php
@@ -3,10 +3,13 @@
 namespace Accompli\Test\EventDispatcher\Subscriber;
 
 use Accompli\AccompliEvents;
+use Accompli\EventDispatcher\Event\LogEvent;
 use Accompli\EventDispatcher\Subscriber\LogSubscriber;
 use Accompli\Task\CreateWorkspaceTask;
 use PHPUnit_Framework_TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * LogSubscriberTest.
@@ -29,7 +32,8 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
+                ->getMock();
 
         $logSubscriber = new LogSubscriber($loggerMock);
 
@@ -43,18 +47,30 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
      */
     public function testOnLogEvent()
     {
-        $eventSubscriberMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')->getMock();
+        $eventSubscriberMock = $this->getMockBuilder(EventSubscriberInterface::class)
+                ->getMock();
 
-        $logEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+        $logEventMock = $this->getMockBuilder(LogEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $logEventMock->expects($this->once())->method('getLevel')->willReturn(LogLevel::DEBUG);
-        $logEventMock->expects($this->once())->method('getMessage')->willReturn('Test');
-        $logEventMock->expects($this->once())->method('getEventNameContext')->willReturn('accompli.test');
-        $logEventMock->expects($this->once())->method('getEventSubscriberContext')->willReturn($eventSubscriberMock);
-        $logEventMock->expects($this->once())->method('getContext')->willReturn(array());
+        $logEventMock->expects($this->once())
+                ->method('getLevel')
+                ->willReturn(LogLevel::DEBUG);
+        $logEventMock->expects($this->once())
+                ->method('getMessage')
+                ->willReturn('Test');
+        $logEventMock->expects($this->once())
+                ->method('getEventNameContext')
+                ->willReturn('accompli.test');
+        $logEventMock->expects($this->once())
+                ->method('getEventSubscriberContext')
+                ->willReturn($eventSubscriberMock);
+        $logEventMock->expects($this->once())
+                ->method('getContext')
+                ->willReturn(array());
 
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
+                ->getMock();
         $loggerMock->expects($this->once())
                 ->method('log')
                 ->with(
@@ -76,16 +92,27 @@ class LogSubscriberTest extends PHPUnit_Framework_TestCase
     {
         $eventSubscriber = new CreateWorkspaceTask();
 
-        $logEventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\LogEvent')
+        $logEventMock = $this->getMockBuilder(LogEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $logEventMock->expects($this->once())->method('getLevel')->willReturn(LogLevel::DEBUG);
-        $logEventMock->expects($this->once())->method('getMessage')->willReturn('Test');
-        $logEventMock->expects($this->once())->method('getEventNameContext')->willReturn('accompli.test');
-        $logEventMock->expects($this->once())->method('getEventSubscriberContext')->willReturn($eventSubscriber);
-        $logEventMock->expects($this->once())->method('getContext')->willReturn(array());
+        $logEventMock->expects($this->once())
+                ->method('getLevel')
+                ->willReturn(LogLevel::DEBUG);
+        $logEventMock->expects($this->once())
+                ->method('getMessage')
+                ->willReturn('Test');
+        $logEventMock->expects($this->once())
+                ->method('getEventNameContext')
+                ->willReturn('accompli.test');
+        $logEventMock->expects($this->once())
+                ->method('getEventSubscriberContext')
+                ->willReturn($eventSubscriber);
+        $logEventMock->expects($this->once())
+                ->method('getContext')
+                ->willReturn(array());
 
-        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)
+                ->getMock();
         $loggerMock->expects($this->once())
                 ->method('log')
                 ->with(

--- a/tests/Exception/TaskCommandExecutionExceptionTest.php
+++ b/tests/Exception/TaskCommandExecutionExceptionTest.php
@@ -2,8 +2,10 @@
 
 namespace Accompli\Test\Exception;
 
+use Accompli\Chrono\Process\ProcessExecutionResult;
 use Accompli\Exception\TaskCommandExecutionException;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * TaskCommandExecutionExceptionTest.
@@ -17,11 +19,11 @@ class TaskCommandExecutionExceptionTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $processExecutionResultMock = $this->getMockBuilder('Accompli\Chrono\Process\ProcessExecutionResult')
+        $processExecutionResultMock = $this->getMockBuilder(ProcessExecutionResult::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+        $taskMock = $this->getMockBuilder(EventSubscriberInterface::class)
                 ->getMock();
 
         $exception = new TaskCommandExecutionException('Test exception', $processExecutionResultMock, $taskMock);
@@ -38,7 +40,7 @@ class TaskCommandExecutionExceptionTest extends PHPUnit_Framework_TestCase
      */
     public function testGetProcessExecutionResult()
     {
-        $processExecutionResultMock = $this->getMockBuilder('Accompli\Chrono\Process\ProcessExecutionResult')
+        $processExecutionResultMock = $this->getMockBuilder(ProcessExecutionResult::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/Exception/TaskRuntimeExceptionTest.php
+++ b/tests/Exception/TaskRuntimeExceptionTest.php
@@ -4,6 +4,7 @@ namespace Accompli\Test\Exception;
 
 use Accompli\Exception\TaskRuntimeException;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * TaskRuntimeExceptionTest.
@@ -17,7 +18,7 @@ class TaskRuntimeExceptionTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+        $taskMock = $this->getMockBuilder(EventSubscriberInterface::class)
                 ->getMock();
 
         $exception = new TaskRuntimeException('Test exception', $taskMock);
@@ -33,7 +34,7 @@ class TaskRuntimeExceptionTest extends PHPUnit_Framework_TestCase
      */
     public function testGetTask()
     {
-        $taskMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')
+        $taskMock = $this->getMockBuilder(EventSubscriberInterface::class)
                 ->getMock();
 
         $exception = new TaskRuntimeException('Test exception', $taskMock);

--- a/tests/Report/AbstractReportTest.php
+++ b/tests/Report/AbstractReportTest.php
@@ -2,9 +2,14 @@
 
 namespace Accompli\Test\Report;
 
+use Accompli\Console\Logger\ConsoleLoggerInterface;
+use Accompli\DataCollector\DataCollectorInterface;
 use Accompli\DataCollector\EventDataCollector;
+use Accompli\Report\AbstractReport;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LogLevel;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * AbstractReportTest.
@@ -18,10 +23,10 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
-        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+        $eventDataCollectorMock = $this->getMockBuilder(EventDataCollector::class)
                 ->getMock();
 
-        $report = $this->getMockBuilder('Accompli\Report\AbstractReport')
+        $report = $this->getMockBuilder(AbstractReport::class)
                 ->setConstructorArgs(array($eventDataCollectorMock, array($eventDataCollectorMock)))
                 ->getMockForAbstractClass();
 
@@ -40,19 +45,19 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
      */
     public function testGenerate(EventDataCollector $eventDataCollectorMock, $beforeAfterTitleBlockLine, $titleBlockLine)
     {
-        $dataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\DataCollectorInterface')
+        $dataCollectorMock = $this->getMockBuilder(DataCollectorInterface::class)
                 ->getMock();
         $dataCollectorMock->expects($this->once())
                 ->method('getData')
                 ->willReturn(array('Test item' => 'Test item data'));
 
-        $outputFormatterMock = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterInterface')
+        $outputFormatterMock = $this->getMockBuilder(OutputFormatterInterface::class)
                 ->getMock();
         $outputFormatterMock->expects($this->any())
                 ->method('format')
                 ->willReturnArgument(0);
 
-        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+        $outputMock = $this->getMockBuilder(OutputInterface::class)
                 ->getMock();
         $outputMock->expects($this->any())
                 ->method('getFormatter')
@@ -80,13 +85,13 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
                     array($this->equalTo(' '))
                 );
 
-        $loggerMock = $this->getMockBuilder('Accompli\Console\Logger\ConsoleLoggerInterface')
+        $loggerMock = $this->getMockBuilder(ConsoleLoggerInterface::class)
                 ->getMock();
         $loggerMock->expects($this->once())
                 ->method('getOutput')
                 ->willReturn($outputMock);
 
-        $report = $this->getMockBuilder('Accompli\Report\AbstractReport')
+        $report = $this->getMockBuilder(AbstractReport::class)
                 ->setConstructorArgs(array($eventDataCollectorMock, array($eventDataCollectorMock, $dataCollectorMock)))
                 ->getMockForAbstractClass();
 
@@ -102,7 +107,7 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
     {
         $provide = array();
 
-        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+        $eventDataCollectorMock = $this->getMockBuilder(EventDataCollector::class)
                 ->getMock();
         $eventDataCollectorMock->expects($this->once())
                 ->method('getData')
@@ -110,7 +115,7 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
 
         $provide[] = array($eventDataCollectorMock, '<fg=black;bg=green>', '<fg=black;bg=green> [OK]');
 
-        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+        $eventDataCollectorMock = $this->getMockBuilder(EventDataCollector::class)
                 ->getMock();
         $eventDataCollectorMock->expects($this->once())
                 ->method('hasCountedFailedEvents')
@@ -121,7 +126,7 @@ class AbstractReportTest extends PHPUnit_Framework_TestCase
 
         $provide[] = array($eventDataCollectorMock, '<fg=white;bg=red>', '<fg=white;bg=red> [FAILURE]');
 
-        $eventDataCollectorMock = $this->getMockBuilder('Accompli\DataCollector\EventDataCollector')
+        $eventDataCollectorMock = $this->getMockBuilder(EventDataCollector::class)
                 ->getMock();
         $eventDataCollectorMock->expects($this->once())
                 ->method('hasCountedLogLevel')

--- a/tests/Task/AbstractConnectedTaskTest.php
+++ b/tests/Task/AbstractConnectedTaskTest.php
@@ -2,6 +2,10 @@
 
 namespace Accompli\Test\Task;
 
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Exception\ConnectionException;
+use Accompli\Task\AbstractConnectedTask;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -16,18 +20,26 @@ class AbstractConnectedTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testEnsureConnectionReturnsConnectionAdapterWhenConnected()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task = $this->getMockBuilder(AbstractConnectedTask::class)
+                ->getMockForAbstractClass();
 
-        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $task->ensureConnection($hostMock));
+        $this->assertInstanceOf(ConnectionAdapterInterface::class, $task->ensureConnection($hostMock));
     }
 
     /**
@@ -35,60 +47,89 @@ class AbstractConnectedTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testEnsureConnectionReturnsConnectionAdapterWhenAbleToConnect()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(false);
-        $connectionAdapterMock->expects($this->once())->method('connect')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(false);
+        $connectionAdapterMock->expects($this->once())
+                ->method('connect')
+                ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task = $this->getMockBuilder(AbstractConnectedTask::class)
+                ->getMockForAbstractClass();
 
-        $this->assertInstanceOf('Accompli\Deployment\Connection\ConnectionAdapterInterface', $task->ensureConnection($hostMock));
+        $this->assertInstanceOf(ConnectionAdapterInterface::class, $task->ensureConnection($hostMock));
     }
 
     /**
      * Tests if AbstractConnectedTask::ensureConnection throws a ConnectionException when the connection adapter is not connected and not able to connect.
-     *
-     * @expectedException        Accompli\Exception\ConnectionException
-     * @expectedExceptionMessage Could not connect to "accompli.deployment.net" through "test".
      */
     public function testEnsureConnectionThrowsConnectionExceptionWhenNotConnectedAndNotAbleToConnect()
     {
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(false);
-        $connectionAdapterMock->expects($this->once())->method('connect')->willReturn(false);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(false);
+        $connectionAdapterMock->expects($this->once())
+                ->method('connect')
+                ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getHostname')->willReturn('accompli.deployment.net');
-        $hostMock->expects($this->once())->method('getConnectionType')->willReturn('test');
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getHostname')
+                ->willReturn('accompli.deployment.net');
+        $hostMock->expects($this->once())
+                ->method('getConnectionType')
+                ->willReturn('test');
 
-        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task = $this->getMockBuilder(AbstractConnectedTask::class)
+                ->getMockForAbstractClass();
+
+        $this->setExpectedException(ConnectionException::class, 'Could not connect to "accompli.deployment.net" through "test".');
+
         $task->ensureConnection($hostMock);
     }
 
     /**
      * Tests if AbstractConnectedTask::ensureConnection throws a ConnectionException when a connection adapter is not available on the Host instance.
-     *
-     * @expectedException        Accompli\Exception\ConnectionException
-     * @expectedExceptionMessage No connection adapter of type "test" found on host.
      */
     public function testEnsureConnectionThrowsConnectionExceptionWhenNoConnectionAdapterAvailable()
     {
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(false);
-        $hostMock->expects($this->once())->method('getConnectionType')->willReturn('test');
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(false);
+        $hostMock->expects($this->once())
+                ->method('getConnectionType')
+                ->willReturn('test');
 
-        $task = $this->getMockBuilder('Accompli\Task\AbstractConnectedTask')->getMockForAbstractClass();
+        $task = $this->getMockBuilder(AbstractConnectedTask::class)
+                ->getMockForAbstractClass();
+
+        $this->setExpectedException(ConnectionException::class, 'No connection adapter of type "test" found on host.');
+
         $task->ensureConnection($hostMock);
     }
 }

--- a/tests/Task/ComposerInstallTaskTest.php
+++ b/tests/Task/ComposerInstallTaskTest.php
@@ -4,11 +4,17 @@ namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\InstallReleaseEvent;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskCommandExecutionException;
+use Accompli\Exception\TaskRuntimeException;
 use Accompli\Task\ComposerInstallTask;
 use PHPUnit_Framework_TestCase;
-use Symfony\Component\Yaml\Exception\RuntimeException;
 
 /**
  * ComposerInstallTaskTest.
@@ -43,12 +49,12 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInstallComposerInstallsComposer()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(5))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('isFile')
@@ -65,7 +71,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->with('php composer.phar self-update')
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -78,7 +84,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -94,18 +100,18 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInstallComposerFailsInstallingComposer()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(1))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('isFile')
                 ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -115,14 +121,14 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
         $event = new WorkspaceEvent($hostMock);
         $event->setWorkspace($workspaceMock);
 
-        $this->setExpectedException('Accompli\Exception\TaskRuntimeException', 'Failed installing the Composer binary.');
+        $this->setExpectedException(TaskRuntimeException::class, 'Failed installing the Composer binary.');
 
         $task = new ComposerInstallTask();
         $task->onPrepareWorkspaceInstallComposer($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
@@ -133,12 +139,12 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInstallComposerUpdatesComposer()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isFile')
@@ -148,13 +154,17 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->with('php composer.phar self-update')
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -170,12 +180,12 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInstallComposerFailsUpdatingComposer()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isFile')
@@ -185,7 +195,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->with('php composer.phar self-update')
                 ->willReturn(new ProcessExecutionResult(1, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -195,7 +205,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -211,13 +221,13 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInstallComposerThrowsRuntimeExceptionWhenWorkspaceInstanceNotAvailable()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -229,7 +239,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
 
         $event = new WorkspaceEvent($hostMock);
 
-        $this->setExpectedException('Accompli\Exception\TaskRuntimeException', 'The workspace of the host has not been created.');
+        $this->setExpectedException(TaskRuntimeException::class, 'The workspace of the host has not been created.');
 
         $task = new ComposerInstallTask();
         $task->onPrepareWorkspaceInstallComposer($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
@@ -240,19 +250,19 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseExecuteComposerInstall()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with('php composer.phar install --no-interaction --working-dir="{workspace}/0.1.0" --no-dev --no-scripts --optimize-autoloader')
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -262,14 +272,14 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(2))
@@ -290,12 +300,12 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseExecuteComposerInstallWithAuthentication()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('putContents')
@@ -314,7 +324,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
         $connectionAdapterMock->expects($this->once())
                 ->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -324,14 +334,14 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(2))
@@ -352,19 +362,19 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseExecuteComposerInstallFails()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(1))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with('php composer.phar install --no-interaction --working-dir="{workspace}/0.1.0" --no-dev --no-scripts --optimize-autoloader')
                 ->willReturn(new ProcessExecutionResult(1, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -374,14 +384,14 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(2))
@@ -393,7 +403,7 @@ class ComposerInstallTaskTest extends PHPUnit_Framework_TestCase
 
         $event = new InstallReleaseEvent($releaseMock);
 
-        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed installing Composer dependencies.');
+        $this->setExpectedException(TaskCommandExecutionException::class, 'Failed installing Composer dependencies.');
 
         $task = new ComposerInstallTask();
         $task->onInstallReleaseExecuteComposerInstall($event, AccompliEvents::INSTALL_RELEASE, $eventDispatcherMock);

--- a/tests/Task/CreateWorkspaceTaskTest.php
+++ b/tests/Task/CreateWorkspaceTaskTest.php
@@ -3,7 +3,11 @@
 namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use Accompli\Task\CreateWorkspaceTask;
 use PHPUnit_Framework_TestCase;
 use RuntimeException;
@@ -58,10 +62,12 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceConstructWorkspaceInstance()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -70,7 +76,7 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
         $task = new CreateWorkspaceTask();
         $task->onPrepareWorkspaceConstructWorkspaceInstance($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
 
-        $this->assertInstanceOf('Accompli\Deployment\Workspace', $event->getWorkspace());
+        $this->assertInstanceOf(Workspace::class, $event->getWorkspace());
         $this->assertSame('/releases/', $event->getWorkspace()->getReleasesDirectory());
         $this->assertSame('/data/', $event->getWorkspace()->getDataDirectory());
         $this->assertSame('/cache/', $event->getWorkspace()->getCacheDirectory());
@@ -80,30 +86,44 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
      * Tests if CreateWorkspaceTask::onPrepareWorkspaceCreateWorkspace throws a RuntimeException when the workspace path does not exist and cannot be created.
      *
      * @depends testOnPrepareWorkspaceConstructWorkspaceInstance
-     *
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage The workspace path "" does not exist and could not be created.
      */
     public function testOnPrepareWorkspaceCreateWorkspaceThrowsRuntimeExceptionOnInaccessibleWorkspacePath()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
-        $connectionAdapterMock->expects($this->once())->method('isDirectory')->willReturn(false);
-        $connectionAdapterMock->expects($this->once())->method('createDirectory')->with('')->willReturn(false);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
+        $connectionAdapterMock->expects($this->once())
+                ->method('isDirectory')
+                ->willReturn(false);
+        $connectionAdapterMock->expects($this->once())
+                ->method('createDirectory')
+                ->with('')
+                ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
         $task = new CreateWorkspaceTask();
         $task->onPrepareWorkspaceConstructWorkspaceInstance($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
+
+        $this->setExpectedException(RuntimeException::class, 'The workspace path "" does not exist and could not be created.');
+
         $task->onPrepareWorkspaceCreateWorkspace($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
     }
 
@@ -114,10 +134,13 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceCreateWorkspace()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(8))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(8))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
                 ->willReturn(true);
@@ -129,11 +152,15 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
                 ->withConsecutive(array('/releases/'), array('/data/'), array('/cache/'))
                 ->willReturnOnConsecutiveCalls(true, true, true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
@@ -149,11 +176,16 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceCreateWorkspaceFailure()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(8))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(8))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->exactly(4))
                 ->method('isDirectory')
                 ->willReturnOnConsecutiveCalls(true, false, false, false);
@@ -162,11 +194,15 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
                 ->withConsecutive(array('/releases/'), array('/data/'), array('/cache/'))
                 ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
@@ -182,19 +218,31 @@ class CreateWorkspaceTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceCreateWorkspaceExists()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(8))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(8))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
-        $connectionAdapterMock->expects($this->exactly(4))->method('isDirectory')->willReturn(true);
-        $connectionAdapterMock->expects($this->never())->method('createDirectory');
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
+        $connectionAdapterMock->expects($this->exactly(4))
+                ->method('isDirectory')
+                ->willReturn(true);
+        $connectionAdapterMock->expects($this->never())
+                ->method('createDirectory');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 

--- a/tests/Task/DeployReleaseTaskTest.php
+++ b/tests/Task/DeployReleaseTaskTest.php
@@ -3,8 +3,13 @@
 namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Deployment\Host;
 use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
+use Accompli\EventDispatcher\Event\DeployReleaseEvent;
+use Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use Accompli\Task\DeployReleaseTask;
 use PHPUnit_Framework_TestCase;
 use RuntimeException;
@@ -32,26 +37,38 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseConstructReleaseInstances()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->once())
                 ->method('isDirectory')
                 ->with($this->equalTo('/path/to/workspace/releases/0.1.0'))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
-        $workspaceMock->expects($this->once())->method('getReleasesDirectory')->willReturn('/path/to/workspace/releases');
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getReleasesDirectory')
+                ->willReturn('/path/to/workspace/releases');
         $workspaceMock->expects($this->once())
                 ->method('addRelease')
                 ->with($this->callback(function ($release) use ($workspaceMock) {
@@ -62,11 +79,15 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                     return ($release instanceof Release);
                 }));
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
-        $eventMock->expects($this->once())->method('getVersion')->willReturn('0.1.0');
+        $eventMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
+        $eventMock->expects($this->once())
+                ->method('getVersion')
+                ->willReturn('0.1.0');
         $eventMock->expects($this->once())
                 ->method('setRelease')
                 ->with($this->callback(function ($release) {
@@ -84,11 +105,16 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseConstructReleaseInstancesWithCurrentRelease()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->once())->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->once())
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->once())
                 ->method('isDirectory')
                 ->with($this->equalTo('/path/to/workspace/releases//0.1.0'))
@@ -102,19 +128,31 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('/path/to/workspace/test'))
                 ->willReturn('/path/to/workspace/releases/0.1.0');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace');
-        $hostMock->expects($this->once())->method('getStage')->willReturn(Host::STAGE_TEST);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace');
+        $hostMock->expects($this->once())
+                ->method('getStage')
+                ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
-        $workspaceMock->expects($this->exactly(3))->method('getReleasesDirectory')->willReturn('/path/to/workspace/releases/');
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
+        $workspaceMock->expects($this->exactly(3))
+                ->method('getReleasesDirectory')
+                ->willReturn('/path/to/workspace/releases/');
         $workspaceMock->expects($this->exactly(2))
                 ->method('addRelease')
                 ->with($this->callback(function ($release) use ($workspaceMock) {
@@ -125,11 +163,15 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                     return ($release instanceof Release && $release->getVersion() === '0.1.0');
                 }));
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
-        $eventMock->expects($this->once())->method('getVersion')->willReturn('0.1.0');
+        $eventMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
+        $eventMock->expects($this->once())
+                ->method('getVersion')
+                ->willReturn('0.1.0');
         $eventMock->expects($this->once())
                 ->method('setRelease')
                 ->with($this->callback(function ($release) {
@@ -149,28 +191,37 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      * Tests if DeployReleaseTask::onPrepareDeployReleaseConstructReleaseInstances throws a RuntimeException when the directory of the release currently being deployed isn't found within the workspace.
      *
      * @depends testOnPrepareDeployReleaseConstructReleaseInstances
-     *
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage The release "0.1.0" is not installed within the workspace.
      */
     public function testOnPrepareDeployReleaseConstructReleaseInstancesThrowsRuntimeExceptionWhenPathToReleaseDoesNotExist()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
-        $connectionAdapterMock->expects($this->once())->method('isDirectory')->willReturn(false);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
+        $connectionAdapterMock->expects($this->once())
+                ->method('isDirectory')
+                ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
         $workspaceMock->expects($this->once())
                 ->method('addRelease')
                 ->with($this->callback(function ($release) use ($workspaceMock) {
@@ -181,14 +232,22 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                     return ($release instanceof Release);
                 }));
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
-        $eventMock->expects($this->once())->method('getVersion')->willReturn('0.1.0');
-        $eventMock->expects($this->never())->method('setRelease');
+        $eventMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
+        $eventMock->expects($this->once())
+                ->method('getVersion')
+                ->willReturn('0.1.0');
+        $eventMock->expects($this->never())
+                ->method('setRelease');
 
         $task = new DeployReleaseTask();
+
+        $this->setExpectedException(RuntimeException::class, 'The release "0.1.0" is not installed within the workspace.');
+
         $task->onPrepareDeployReleaseConstructReleaseInstances($eventMock, AccompliEvents::PREPARE_DEPLOY_RELEASE, $eventDispatcherMock);
     }
 
@@ -197,11 +256,16 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnDeployReleaseLinkReleaseWithoutCurrentRelease()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('isLink')
                 ->with($this->equalTo('/path/to/workspace/test'))
@@ -210,31 +274,48 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                 ->method('link')
                 ->with($this->equalTo('/path/to/workspace/releases/0.1.0'), $this->equalTo('/path/to/workspace/test'))
                 ->willReturn(true);
-        $connectionAdapterMock->expects($this->never())->method('delete');
+        $connectionAdapterMock->expects($this->never())
+                ->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace');
-        $hostMock->expects($this->once())->method('getStage')->willReturn(Host::STAGE_TEST);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace');
+        $hostMock->expects($this->once())
+                ->method('getStage')
+                ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace/releases/0.1.0');
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
+        $releaseMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace/releases/0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\DeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(DeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getRelease')->willReturn($releaseMock);
+        $eventMock->expects($this->once())
+                ->method('getRelease')
+                ->willReturn($releaseMock);
 
         $task = new DeployReleaseTask();
         $task->onDeployOrRollbackReleaseLinkRelease($eventMock, AccompliEvents::DEPLOY_RELEASE, $eventDispatcherMock);
@@ -247,11 +328,16 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnDeployReleaseLinkReleaseWithCurrentRelease()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('isLink')
                 ->with($this->equalTo('/path/to/workspace/test'))
@@ -268,29 +354,45 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                 ->method('delete')
                 ->with($this->equalTo('/path/to/workspace/test'), $this->equalTo(false));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace');
-        $hostMock->expects($this->once())->method('getStage')->willReturn(Host::STAGE_TEST);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace');
+        $hostMock->expects($this->once())
+                ->method('getStage')
+                ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->exactly(2))->method('getPath')->willReturn('/path/to/workspace/releases/0.1.0');
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
+        $releaseMock->expects($this->exactly(2))
+                ->method('getPath')
+                ->willReturn('/path/to/workspace/releases/0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\DeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(DeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getRelease')->willReturn($releaseMock);
+        $eventMock->expects($this->once())
+                ->method('getRelease')
+                ->willReturn($releaseMock);
 
         $task = new DeployReleaseTask();
         $task->onDeployOrRollbackReleaseLinkRelease($eventMock, AccompliEvents::DEPLOY_RELEASE, $eventDispatcherMock);
@@ -303,11 +405,16 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnDeployReleaseLinkReleaseWithCurrentReleaseIsSameAsReleaseBeingDeployed()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->once())
                 ->method('isLink')
                 ->with($this->equalTo('/path/to/workspace/test'))
@@ -319,29 +426,45 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
                 ->willReturn('/path/to/workspace/releases/0.1.0');
         $connectionAdapterMock->expects($this->never())->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace');
-        $hostMock->expects($this->once())->method('getStage')->willReturn(Host::STAGE_TEST);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace');
+        $hostMock->expects($this->once())
+                ->method('getStage')
+                ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace/releases/0.1.0');
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
+        $releaseMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace/releases/0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\DeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(DeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getRelease')->willReturn($releaseMock);
+        $eventMock->expects($this->once())
+                ->method('getRelease')
+                ->willReturn($releaseMock);
 
         $task = new DeployReleaseTask();
         $task->onDeployOrRollbackReleaseLinkRelease($eventMock, AccompliEvents::DEPLOY_RELEASE, $eventDispatcherMock);
@@ -351,50 +474,76 @@ class DeployReleaseTaskTest extends PHPUnit_Framework_TestCase
      * Tests if DeployReleaseTask::onDeployReleaseLinkRelease throws a RuntimeException when linking to a release fails.
      *
      * @depends testOnDeployReleaseLinkReleaseWithCurrentReleaseIsSameAsReleaseBeingDeployed
-     *
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage Linking "/path/to/workspace/test" to release "0.1.0" failed.
      */
     public function testOnDeployReleaseLinkReleaseThrowsRuntimeExceptionWhenLinkingFails()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->once())->method('isConnected')->willReturn(true);
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->once())
+                ->method('isConnected')
+                ->willReturn(true);
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('isLink')
                 ->with($this->equalTo('/path/to/workspace/test'))
                 ->willReturn(false);
-        $connectionAdapterMock->expects($this->once())->method('link')->willReturn(false);
-        $connectionAdapterMock->expects($this->never())->method('delete');
+        $connectionAdapterMock->expects($this->once())
+                ->method('link')
+                ->willReturn(false);
+        $connectionAdapterMock->expects($this->never())
+                ->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace');
-        $hostMock->expects($this->once())->method('getStage')->willReturn(Host::STAGE_TEST);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace');
+        $hostMock->expects($this->once())
+                ->method('getStage')
+                ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->once())->method('getPath')->willReturn('/path/to/workspace/releases/0.1.0');
-        $releaseMock->expects($this->once())->method('getVersion')->willReturn('0.1.0');
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
+        $releaseMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('/path/to/workspace/releases/0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getVersion')
+                ->willReturn('0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\DeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(DeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $eventMock->expects($this->once())->method('getRelease')->willReturn($releaseMock);
+        $eventMock->expects($this->once())
+                ->method('getRelease')
+                ->willReturn($releaseMock);
 
         $task = new DeployReleaseTask();
+
+        $this->setExpectedException(RuntimeException::class, 'Linking "/path/to/workspace/test" to release "0.1.0" failed.');
+
         $task->onDeployOrRollbackReleaseLinkRelease($eventMock, AccompliEvents::DEPLOY_RELEASE, $eventDispatcherMock);
     }
 }

--- a/tests/Task/ExecuteCommandTaskTest.php
+++ b/tests/Task/ExecuteCommandTaskTest.php
@@ -4,8 +4,14 @@ namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\PrepareReleaseEvent;
 use Accompli\EventDispatcher\Event\ReleaseEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskCommandExecutionException;
 use Accompli\Task\ExecuteCommandTask;
 use PHPUnit_Framework_TestCase;
 
@@ -45,23 +51,31 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnEventWithPrepareReleaseEvent()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(3))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->exactly(2))
+                ->method('changeWorkingDirectory');
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with($this->equalTo('echo'), $this->equalTo(array('test')))
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
@@ -79,30 +93,38 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnEventWithReleaseEvent()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(3))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(3))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->exactly(2))
+                ->method('changeWorkingDirectory');
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with($this->equalTo('echo'), $this->equalTo(array('test')))
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->once())
@@ -120,30 +142,38 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnEventFailure()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(1))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(1))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
-        $connectionAdapterMock->expects($this->exactly(2))->method('changeWorkingDirectory');
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
+        $connectionAdapterMock->expects($this->exactly(2))
+                ->method('changeWorkingDirectory');
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with($this->equalTo('echo'), $this->equalTo(array('test')))
                 ->willReturn(new ProcessExecutionResult(1, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->once())
@@ -152,7 +182,7 @@ class ExecuteCommandTaskTest extends PHPUnit_Framework_TestCase
 
         $event = new ReleaseEvent($releaseMock);
 
-        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed executing command "echo".');
+        $this->setExpectedException(TaskCommandExecutionException::class, 'Failed executing command "echo".');
 
         $task = new ExecuteCommandTask(array(AccompliEvents::INSTALL_RELEASE), 'echo', array('test'));
         $task->onEvent($event, AccompliEvents::INSTALL_RELEASE, $eventDispatcherMock);

--- a/tests/Task/MaintenanceModeTaskTest.php
+++ b/tests/Task/MaintenanceModeTaskTest.php
@@ -3,10 +3,18 @@
 namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
+use Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent;
+use Accompli\EventDispatcher\Event\WorkspaceEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskRuntimeException;
 use Accompli\Task\MaintenanceModeTask;
 use Accompli\Utility\VersionCategoryComparator;
+use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
-use RuntimeException;
 
 /**
  * MaintenanceModeTaskTest.
@@ -38,12 +46,11 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests if constructing a new MaintenanceTask with an invalid strategy throws an InvalidArgumentException.
-     *
-     * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage The strategy type "invalid" is invalid.
      */
     public function testConstructThrowsInvalidArgumentException()
     {
+        $this->setExpectedException(InvalidArgumentException::class, 'The strategy type "invalid" is invalid.');
+
         new MaintenanceModeTask('invalid');
     }
 
@@ -52,12 +59,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceUploadMaintenancePage()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->atLeast(4))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -73,7 +80,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('putFile')
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -86,14 +93,14 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(1))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\WorkspaceEvent')
+        $eventMock = $this->getMockBuilder(WorkspaceEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->exactly(1))
@@ -109,12 +116,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceUploadMaintenancePageToDocumentRootSubdirectory()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->atLeast(4))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -131,7 +138,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->anything(), $this->stringStartsWith('{workspace}/maintenance/web/'))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -144,14 +151,14 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(1))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\WorkspaceEvent')
+        $eventMock = $this->getMockBuilder(WorkspaceEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->exactly(1))
@@ -167,12 +174,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceUploadMaintenancePageWhenMaintenanceExists()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->atLeast(4))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -186,7 +193,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('putFile')
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -196,14 +203,14 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(1))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\WorkspaceEvent')
+        $eventMock = $this->getMockBuilder(WorkspaceEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->exactly(1))
@@ -219,12 +226,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceUploadMaintenancePageFailure()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -239,7 +246,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('putFile')
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -252,14 +259,14 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(1))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\WorkspaceEvent')
+        $eventMock = $this->getMockBuilder(WorkspaceEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->exactly(1))
@@ -275,12 +282,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseLinkMaintenancePageToStage()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -295,7 +302,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
         $connectionAdapterMock->expects($this->never())
                 ->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -311,18 +318,18 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->once())
@@ -341,12 +348,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseLinkMaintenancePageToStageWhenStageLinkExists()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -363,7 +370,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->with('{workspace}/test', false)
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -379,18 +386,18 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getPath')
                 ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->once())
@@ -409,12 +416,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseLinkMaintenancePageToStageDoesNotExecuteWhenVersionCategoryDifferenceDoesNotMatchStrategy()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(1))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->never())
                 ->method('isConnected');
@@ -425,7 +432,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
         $connectionAdapterMock->expects($this->never())
                 ->method('delete');
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->never())
@@ -435,20 +442,20 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
         $hostMock->expects($this->never())
                 ->method('getStage');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->never())
                 ->method('getHost');
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(2))
                 ->method('getVersion')
                 ->willReturn('0.1.0');
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->never())
@@ -469,12 +476,12 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareDeployReleaseLinkMaintenancePageToStageFailure()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(3))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('isConnected')
@@ -490,7 +497,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->with('/maintenance/', '/test')
                 ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -503,18 +510,18 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getStage')
                 ->willReturn('test');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $eventMock = $this->getMockBuilder('Accompli\EventDispatcher\Event\PrepareDeployReleaseEvent')
+        $eventMock = $this->getMockBuilder(PrepareDeployReleaseEvent::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $eventMock->expects($this->once())
@@ -524,7 +531,7 @@ class MaintenanceModeTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getRelease')
                 ->willReturn($releaseMock);
 
-        $this->setExpectedException('RuntimeException', 'Linking "/test" to maintenance page failed.');
+        $this->setExpectedException(TaskRuntimeException::class, 'Linking "/test" to maintenance page failed.');
 
         $task = new MaintenanceModeTask();
         $task->onPrepareDeployReleaseLinkMaintenancePageToStage($eventMock, AccompliEvents::PREPARE_DEPLOY_RELEASE, $eventDispatcherMock);

--- a/tests/Task/RepositoryCheckoutTaskTest.php
+++ b/tests/Task/RepositoryCheckoutTaskTest.php
@@ -4,7 +4,13 @@ namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\PrepareReleaseEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
+use Accompli\Exception\TaskCommandExecutionException;
 use Accompli\Task\RepositoryCheckoutTask;
 use PHPUnit_Framework_TestCase;
 
@@ -41,17 +47,18 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareReleaseConstructReleaseInstance()
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('addRelease');
+        $workspaceMock->expects($this->once())
+                ->method('addRelease');
 
         $event = new PrepareReleaseEvent($workspaceMock, '0.1.0');
 
         $task = new RepositoryCheckoutTask('https://github.com/accompli/accompli.git');
         $task->onPrepareReleaseConstructReleaseInstance($event);
 
-        $this->assertInstanceOf('Accompli\Deployment\Release', $event->getRelease());
+        $this->assertInstanceOf(Release::class, $event->getRelease());
         $this->assertSame('0.1.0', $event->getRelease()->getVersion());
     }
 
@@ -62,12 +69,13 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareReleaseConstructReleaseInstanceDoesNothingWhenReleaseInstanceExists()
     {
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->never())->method('addRelease');
+        $workspaceMock->expects($this->never())
+                ->method('addRelease');
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -77,7 +85,7 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
         $task = new RepositoryCheckoutTask('https://github.com/accompli/accompli.git');
         $task->onPrepareReleaseConstructReleaseInstance($event);
 
-        $this->assertInstanceOf('Accompli\Deployment\Release', $event->getRelease());
+        $this->assertInstanceOf(Release::class, $event->getRelease());
     }
 
     /**
@@ -87,10 +95,13 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareReleaseCheckoutRepository()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->withConsecutive(
@@ -99,22 +110,30 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
-        $releaseMock->expects($this->exactly(2))->method('getVersion')->willReturn('0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
+        $releaseMock->expects($this->exactly(2))
+                ->method('getVersion')
+                ->willReturn('0.1.0');
 
         $event = new PrepareReleaseEvent($workspaceMock, '0.1.0');
         $event->setRelease($releaseMock);
@@ -130,10 +149,13 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareReleaseCheckoutRepositoryThrowsRuntimeException()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->once())->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->once())
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->willReturnOnConsecutiveCalls(
@@ -141,27 +163,35 @@ class RepositoryCheckoutTaskTest extends PHPUnit_Framework_TestCase
                         new ProcessExecutionResult(1, '', '')
                 );
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $releaseMock->expects($this->once())->method('getWorkspace')->willReturn($workspaceMock);
-        $releaseMock->expects($this->exactly(3))->method('getVersion')->willReturn('0.1.0');
+        $releaseMock->expects($this->once())
+                ->method('getWorkspace')
+                ->willReturn($workspaceMock);
+        $releaseMock->expects($this->exactly(3))
+                ->method('getVersion')
+                ->willReturn('0.1.0');
 
         $event = new PrepareReleaseEvent($workspaceMock, '0.1.0');
         $event->setRelease($releaseMock);
 
-        $this->setExpectedException('Accompli\Exception\TaskCommandExecutionException', 'Failed to checkout version "0.1.0" from repository "https://github.com/accompli/accompli.git".');
+        $this->setExpectedException(TaskCommandExecutionException::class, 'Failed to checkout version "0.1.0" from repository "https://github.com/accompli/accompli.git".');
 
         $task = new RepositoryCheckoutTask('https://github.com/accompli/accompli.git');
         $task->onPrepareReleaseCheckoutRepository($event, AccompliEvents::PREPARE_RELEASE, $eventDispatcherMock);

--- a/tests/Task/SSHAgentTaskTest.php
+++ b/tests/Task/SSHAgentTaskTest.php
@@ -4,8 +4,13 @@ namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
 use Accompli\Chrono\Process\ProcessExecutionResult;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
+use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\InstallReleaseEvent;
 use Accompli\EventDispatcher\Event\WorkspaceEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use Accompli\Task\SSHAgentTask;
 use PHPUnit_Framework_TestCase;
 
@@ -42,20 +47,27 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInitializeSSHAgent()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with($this->equalTo('eval $(ssh-agent)'))
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
@@ -70,20 +82,27 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInitializeSSHAgentFails()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(2))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->once())
                 ->method('executeCommand')
                 ->with($this->equalTo('eval $(ssh-agent)'))
                 ->willReturn(new ProcessExecutionResult(1, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
@@ -98,10 +117,13 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInitializeSSHAgentAddSSHKey()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(4))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(4))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->withConsecutive(
@@ -122,17 +144,25 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('{workspace}/tmp.key'))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('{workspace}');
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
         $event = new WorkspaceEvent($hostMock);
         $event->setWorkspace($workspaceMock);
@@ -148,10 +178,13 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnPrepareWorkspaceInitializeSSHAgentAddSSHKeyFails()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(4))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(4))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->withConsecutive(
@@ -172,17 +205,25 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('{workspace}/tmp.key'))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->once())->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->once())->method('getConnection')->willReturn($connectionAdapterMock);
-        $hostMock->expects($this->once())->method('getPath')->willReturn('{workspace}');
+        $hostMock->expects($this->once())
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->once())
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->once())
+                ->method('getPath')
+                ->willReturn('{workspace}');
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $workspaceMock->expects($this->once())->method('getHost')->willReturn($hostMock);
+        $workspaceMock->expects($this->once())
+                ->method('getHost')
+                ->willReturn($hostMock);
 
         $event = new WorkspaceEvent($hostMock);
         $event->setWorkspace($workspaceMock);
@@ -198,10 +239,12 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCompleteOrFailedShutdownSSHAgent()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
         $eventDispatcherMock->expects($this->exactly(4))->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->withConsecutive(
@@ -210,18 +253,22 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(new ProcessExecutionResult(0, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->exactly(2))->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->exactly(2))->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->exactly(2))
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->exactly(2))
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
         $task = new SSHAgentTask();
         $task->onPrepareWorkspaceInitializeSSHAgent($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -237,10 +284,13 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCompleteOrFailedShutdownSSHAgentFails()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')->getMock();
-        $eventDispatcherMock->expects($this->exactly(4))->method('dispatch');
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+                ->getMock();
+        $eventDispatcherMock->expects($this->exactly(4))
+                ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')->getMock();
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
+                ->getMock();
         $connectionAdapterMock->expects($this->exactly(2))
                 ->method('executeCommand')
                 ->withConsecutive(
@@ -249,18 +299,22 @@ class SSHAgentTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturnOnConsecutiveCalls(new ProcessExecutionResult(0, '', ''), new ProcessExecutionResult(1, '', ''));
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $hostMock->expects($this->exactly(2))->method('hasConnection')->willReturn(true);
-        $hostMock->expects($this->exactly(2))->method('getConnection')->willReturn($connectionAdapterMock);
+        $hostMock->expects($this->exactly(2))
+                ->method('hasConnection')
+                ->willReturn(true);
+        $hostMock->expects($this->exactly(2))
+                ->method('getConnection')
+                ->willReturn($connectionAdapterMock);
 
         $event = new WorkspaceEvent($hostMock);
 
         $task = new SSHAgentTask();
         $task->onPrepareWorkspaceInitializeSSHAgent($event, AccompliEvents::PREPARE_WORKSPACE, $eventDispatcherMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/tests/Task/YamlConfigurationTaskTest.php
+++ b/tests/Task/YamlConfigurationTaskTest.php
@@ -3,8 +3,12 @@
 namespace Accompli\Test\Task;
 
 use Accompli\AccompliEvents;
+use Accompli\Deployment\Connection\ConnectionAdapterInterface;
 use Accompli\Deployment\Host;
+use Accompli\Deployment\Release;
+use Accompli\Deployment\Workspace;
 use Accompli\EventDispatcher\Event\InstallReleaseEvent;
+use Accompli\EventDispatcher\EventDispatcherInterface;
 use Accompli\Task\YamlConfigurationTask;
 use PHPUnit_Framework_TestCase;
 
@@ -42,12 +46,12 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationCreatesANewConfigurationFile()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -62,7 +66,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('{workspace}/releases/0.1.0/parameters.yml'), $this->stringStartsWith("foo: bar\nbaz: "))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -72,14 +76,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))
@@ -100,12 +104,12 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationCreatesANewConfigurationFileWithEnvironmentVariables()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -120,7 +124,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('{workspace}/releases/0.1.0/parameters.yml'), $this->equalTo("foo: bar_test\nbaz: 0.1.0\nbar:\n    baz: test_0.1.0\n"))
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -133,14 +137,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getStage')
                 ->willReturn(Host::STAGE_TEST);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))
@@ -164,12 +168,12 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationUpdatesExistingConfigurationFile()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -191,7 +195,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -201,14 +205,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))
@@ -229,12 +233,12 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationCreatesANewConfigurationFileFromDistributionFile()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -256,7 +260,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -266,14 +270,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))
@@ -299,10 +303,10 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationCreatesANewStageSpecificConfigurationFile($stage, $expectedConfiguration)
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -324,7 +328,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 )
                 ->willReturn(true);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->exactly(2))
@@ -337,14 +341,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))
@@ -377,12 +381,12 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
      */
     public function testOnInstallReleaseCreateOrUpdateConfigurationFailsCreatingANewConfigurationFile()
     {
-        $eventDispatcherMock = $this->getMockBuilder('Accompli\EventDispatcher\EventDispatcherInterface')
+        $eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
                 ->getMock();
         $eventDispatcherMock->expects($this->exactly(2))
                 ->method('dispatch');
 
-        $connectionAdapterMock = $this->getMockBuilder('Accompli\Deployment\Connection\ConnectionAdapterInterface')
+        $connectionAdapterMock = $this->getMockBuilder(ConnectionAdapterInterface::class)
                 ->getMock();
         $connectionAdapterMock->expects($this->exactly(3))
                 ->method('isFile')
@@ -397,7 +401,7 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->with($this->equalTo('{workspace}/releases/0.1.0/parameters.yml'), $this->stringStartsWith("foo: bar\nbaz: "))
                 ->willReturn(false);
 
-        $hostMock = $this->getMockBuilder('Accompli\Deployment\Host')
+        $hostMock = $this->getMockBuilder(Host::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $hostMock->expects($this->once())
@@ -407,14 +411,14 @@ class YamlConfigurationTaskTest extends PHPUnit_Framework_TestCase
                 ->method('getConnection')
                 ->willReturn($connectionAdapterMock);
 
-        $workspaceMock = $this->getMockBuilder('Accompli\Deployment\Workspace')
+        $workspaceMock = $this->getMockBuilder(Workspace::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $workspaceMock->expects($this->exactly(3))
                 ->method('getHost')
                 ->willReturn($hostMock);
 
-        $releaseMock = $this->getMockBuilder('Accompli\Deployment\Release')
+        $releaseMock = $this->getMockBuilder(Release::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $releaseMock->expects($this->exactly(3))


### PR DESCRIPTION
Explicitly removes PHP 5.4 support by changing the minimum requirement to PHP 5.5 in the Composer configuration.

Also replaced the class strings with class name constants.

Closes #158.
