### PR TITLE
Improve terminal width detection

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -34,6 +34,23 @@ class Application extends BaseApplication
     }
 
     /**
+     * Returns the terminal width.
+     *
+     * @return int
+     */
+    public function getTerminalWidth()
+    {
+        $terminalDimensions = $this->getTerminalDimensions();
+
+        $width = 120;
+        if (isset($terminalDimensions[0]) && $terminalDimensions[0] > 0) {
+            $width = $terminalDimensions[0];
+        }
+
+        return $width;
+    }
+
+    /**
      * Returns the array with default commands.
      *
      * @return array

--- a/src/Console/Helper/TitleBlock.php
+++ b/src/Console/Helper/TitleBlock.php
@@ -2,7 +2,7 @@
 
 namespace Accompli\Console\Helper;
 
-use Symfony\Component\Console\Application;
+use Accompli\Console\Application;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -103,13 +103,7 @@ class TitleBlock extends Title
     private function getTerminalWidth()
     {
         $application = new Application();
-        $terminalDimensions = $application->getTerminalDimensions();
 
-        $width = 120;
-        if (isset($terminalDimensions[0])) {
-            $width = $terminalDimensions[0];
-        }
-
-        return $width;
+        return $application->getTerminalWidth();
     }
 }

--- a/src/Console/Logger/ConsoleLogger.php
+++ b/src/Console/Logger/ConsoleLogger.php
@@ -2,12 +2,12 @@
 
 namespace Accompli\Console\Logger;
 
+use Accompli\Console\Application;
 use Accompli\Console\Formatter\OutputFormatter;
 use Accompli\Task\TaskInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -195,14 +195,8 @@ class ConsoleLogger extends AbstractLogger implements ConsoleLoggerInterface
     public function getTerminalWidth()
     {
         $application = new Application();
-        $terminalDimensions = $application->getTerminalDimensions();
 
-        $width = 120;
-        if (isset($terminalDimensions[0])) {
-            $width = $terminalDimensions[0];
-        }
-
-        return $width;
+        return $application->getTerminalWidth();
     }
 
     /**


### PR DESCRIPTION
Refactors `getTerminalWidth` from both `ConsoleLogger` and `TitleBlock` and adds an extra test if the retrieved terminal width is higher than 0, which seems to be a problem occuring on Travis CI the last few days.